### PR TITLE
Include Source links for SDK Docs

### DIFF
--- a/docs/sdk/client-side-sdks/android.md
+++ b/docs/sdk/client-side-sdks/android.md
@@ -9,6 +9,12 @@ The DevCycle Android Client SDK! This SDK uses our Client SDK APIs to perform al
 and bucketing for the SDK, providing fast response times using our globally distributed edge workers 
 all around the world. 
 
+:::
+
+The SDK is available as a package on MavenCentral. It is also open source and can be viewed on Github.
+[![Maven](https://badgen.net/maven/v/maven-central/com.devcycle/android-client-sdk)](https://search.maven.org/artifact/com.devcycle/android-client-sdk)
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/android-client-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/android-client-sdk)
+
 ## Requirements
 
 This version of the DevCycle Android Client SDK supports a minimum Android API Version 21.
@@ -18,7 +24,7 @@ This version of the DevCycle Android Client SDK supports a minimum Android API V
 The SDK can be installed into your Android project by adding the following to *build.gradle*:
 
 ```yaml
-implementation("com.devcycle:android-client-sdk:1.0.4")
+implementation("com.devcycle:android-client-sdk:1.0.7")
 ```
 
 ## Usage

--- a/docs/sdk/client-side-sdks/android.md
+++ b/docs/sdk/client-side-sdks/android.md
@@ -9,9 +9,8 @@ The DevCycle Android Client SDK! This SDK uses our Client SDK APIs to perform al
 and bucketing for the SDK, providing fast response times using our globally distributed edge workers 
 all around the world. 
 
-:::
-
 The SDK is available as a package on MavenCentral. It is also open source and can be viewed on Github.
+
 [![Maven](https://badgen.net/maven/v/maven-central/com.devcycle/android-client-sdk)](https://search.maven.org/artifact/com.devcycle/android-client-sdk)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/android-client-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/android-client-sdk)
 

--- a/docs/sdk/client-side-sdks/ios.md
+++ b/docs/sdk/client-side-sdks/ios.md
@@ -9,9 +9,7 @@ The iOS Client SDK for DevCycle! This SDK uses our Client SDK APIs to perform al
 and bucketing for the SDK, providing fast response times using our globally distributed edge workers
 all around the world.
 
-:::
-
-The SDK is available as a package on CocoaPods, Carthag and Swift Package Manager. It is also open source and can be viewed on Github.
+The SDK is available as a package on CocoaPods, Carthage and Swift Package Manager. It is also open source and can be viewed on Github.
 
 [![CocoaPods compatible](https://img.shields.io/cocoapods/v/DevCycle.svg)](https://cocoapods.org/pods/DevCycle)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)

--- a/docs/sdk/client-side-sdks/ios.md
+++ b/docs/sdk/client-side-sdks/ios.md
@@ -9,6 +9,15 @@ The iOS Client SDK for DevCycle! This SDK uses our Client SDK APIs to perform al
 and bucketing for the SDK, providing fast response times using our globally distributed edge workers
 all around the world.
 
+:::
+
+The SDK is available as a package on CocoaPods, Carthag and Swift Package Manager. It is also open source and can be viewed on Github.
+
+[![CocoaPods compatible](https://img.shields.io/cocoapods/v/DevCycle.svg)](https://cocoapods.org/pods/DevCycle)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager/)
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/ios-client-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/devcyclehq/ios-client-sdk)
+
 ## Requirements
 
 This version of the DevCycle iOS Client SDK supports a minimum of iOS 12.

--- a/docs/sdk/client-side-sdks/javascript.md
+++ b/docs/sdk/client-side-sdks/javascript.md
@@ -10,6 +10,13 @@ providing immediate responses to variable and feature requests for a user.
 
 The SDK will download the latest version of your DevCycle environments configuration from a CDN on initialization.
 
+:::
+
+The SDK is available as a package on npm. It is also open source and can be viewed on Github.
+
+[![Npm package version](https://badgen.net/npm/v/@devcycle/devcycle-js-sdk)](https://www.npmjs.com/package/@devcycle/devcycle-js-sdk)
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/js-sdks.svg?style=social&label=Star&maxAge=2592000)](https://github.com/devcyclehq/js-sdks)
+
 ## Installation
 
 Our library can be found on npm and installed by the following:

--- a/docs/sdk/client-side-sdks/javascript.md
+++ b/docs/sdk/client-side-sdks/javascript.md
@@ -10,8 +10,6 @@ providing immediate responses to variable and feature requests for a user.
 
 The SDK will download the latest version of your DevCycle environments configuration from a CDN on initialization.
 
-:::
-
 The SDK is available as a package on npm. It is also open source and can be viewed on Github.
 
 [![Npm package version](https://badgen.net/npm/v/@devcycle/devcycle-js-sdk)](https://www.npmjs.com/package/@devcycle/devcycle-js-sdk)

--- a/docs/sdk/client-side-sdks/react.md
+++ b/docs/sdk/client-side-sdks/react.md
@@ -13,14 +13,17 @@ Currently, DevCycle for React only supports access via functional component hook
 
 :::
 
+The SDK is available as a package on npm. It is also open source and can be viewed on Github.
+
+[![Npm package version](https://badgen.net/npm/v/@devcycle/devcycle-react-sdk)](https://www.npmjs.com/package/@devcycle/devcycle-react-sdk)
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/js-sdks.svg?style=social&label=Star&maxAge=2592000)](https://github.com/devcyclehq/js-sdks)
+
 ## Requirements: 
 
 This SDK is compatible with React versions 16.8.0 and above.
 
 
 ## Installation
-
-The DevCycle-react-sdk is available on [npm](https://www.npmjs.com/package/@devcycle/devcycle-react-sdk).
 
 To install the SDK, run the following command:
 

--- a/docs/sdk/server-side-sdks/dotnet-cloud.md
+++ b/docs/sdk/server-side-sdks/dotnet-cloud.md
@@ -8,6 +8,12 @@ sidebar_position: 7
 Welcome to the DevCycle .NET Server SDK, which interfaces with the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 All requests, including user data are sent to DevCycle servers to ensure the User is bucketed correctly and will receive the correct variation.
 
+:::
+
+The SDK is available as a package on Nuget. It is also open source and can be viewed on Github.
+[![Nuget](https://badgen.net/nuget/v/DevCycle.SDK.Server.Cloud)](https://www.nuget.org/packages/DevCycle.SDK.Server.Cloud/)
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/dotnet-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/dotnet-server-sdk)
+
 ## Requirements
 
 ### Frameworks supported

--- a/docs/sdk/server-side-sdks/dotnet-cloud.md
+++ b/docs/sdk/server-side-sdks/dotnet-cloud.md
@@ -8,9 +8,8 @@ sidebar_position: 7
 Welcome to the DevCycle .NET Server SDK, which interfaces with the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 All requests, including user data are sent to DevCycle servers to ensure the User is bucketed correctly and will receive the correct variation.
 
-:::
-
 The SDK is available as a package on Nuget. It is also open source and can be viewed on Github.
+
 [![Nuget](https://badgen.net/nuget/v/DevCycle.SDK.Server.Cloud)](https://www.nuget.org/packages/DevCycle.SDK.Server.Cloud/)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/dotnet-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/dotnet-server-sdk)
 

--- a/docs/sdk/server-side-sdks/dotnet-local.md
+++ b/docs/sdk/server-side-sdks/dotnet-local.md
@@ -13,9 +13,8 @@ Events are queued and flushed periodically in the background to the events api i
 
 This version uses [.NET Standard 2.1](https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1) and utilizes more resources to perform local bucketing.
 
-:::
-
 The SDK is available as a package on Nuget. It is also open source and can be viewed on Github.
+
 [![Nuget](https://badgen.net/nuget/v/DevCycle.SDK.Server.Local)](https://www.nuget.org/packages/DevCycle.SDK.Server.Local/)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/dotnet-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/dotnet-server-sdk)
 

--- a/docs/sdk/server-side-sdks/dotnet-local.md
+++ b/docs/sdk/server-side-sdks/dotnet-local.md
@@ -13,6 +13,12 @@ Events are queued and flushed periodically in the background to the events api i
 
 This version uses [.NET Standard 2.1](https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1) and utilizes more resources to perform local bucketing.
 
+:::
+
+The SDK is available as a package on Nuget. It is also open source and can be viewed on Github.
+[![Nuget](https://badgen.net/nuget/v/DevCycle.SDK.Server.Local)](https://www.nuget.org/packages/DevCycle.SDK.Server.Local/)
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/dotnet-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/dotnet-server-sdk)
+
 ### Frameworks supported
 - .NET & .NET Core >=3.0
 - Mono >=6.4

--- a/docs/sdk/server-side-sdks/go.md
+++ b/docs/sdk/server-side-sdks/go.md
@@ -7,6 +7,11 @@ sidebar_position: 3
 
 Welcome to the the DevCycle Go SDK, initially generated via the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 
+:::
+
+The SDK is open source and can be viewed on Github.
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/go-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/go-server-sdk)
+
 ## Installation
 
 ```bash

--- a/docs/sdk/server-side-sdks/go.md
+++ b/docs/sdk/server-side-sdks/go.md
@@ -7,9 +7,8 @@ sidebar_position: 3
 
 Welcome to the the DevCycle Go SDK, initially generated via the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 
-:::
-
 The SDK is open source and can be viewed on Github.
+
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/go-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/go-server-sdk)
 
 ## Installation

--- a/docs/sdk/server-side-sdks/java.md
+++ b/docs/sdk/server-side-sdks/java.md
@@ -7,9 +7,8 @@ sidebar_position: 6
 
 Welcome to the DevCycle Java SDK, which interfaces with the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 
-:::
-
 The SDK is available as a package on MavenCentral. It is also open source and can be viewed on Github.
+
 [![Maven](https://badgen.net/maven/v/maven-central/com.devcycle/java-server-sdk)](https://search.maven.org/artifact/com.devcycle/java-server-sdk)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/java-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/java-server-sdk)
 

--- a/docs/sdk/server-side-sdks/java.md
+++ b/docs/sdk/server-side-sdks/java.md
@@ -5,7 +5,13 @@ sidebar_position: 6
 
 # DevCycle Java Server SDK
 
-Welcome to the DevCycle Java SDK, which interfaces with the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle). 
+Welcome to the DevCycle Java SDK, which interfaces with the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
+
+:::
+
+The SDK is available as a package on MavenCentral. It is also open source and can be viewed on Github.
+[![Maven](https://badgen.net/maven/v/maven-central/com.devcycle/java-server-sdk)](https://search.maven.org/artifact/com.devcycle/java-server-sdk)
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/java-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/java-server-sdk)
 
 ## Requirements
 
@@ -23,7 +29,7 @@ You can use the SDK in your Maven project by adding the following to your *pom.x
 <dependency>
     <groupId>com.devcycle</groupId>
     <artifactId>java-server-sdk</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.6</version>
     <scope>compile</scope>
 </dependency>
 ```
@@ -32,7 +38,7 @@ You can use the SDK in your Maven project by adding the following to your *pom.x
 Alternatively you can use the SDK in your Gradle project by adding the following to *build.gradle*:
 
 ```yaml
-implementation("com.devcycle:java-server-sdk:1.0.3")
+implementation("com.devcycle:java-server-sdk:1.0.6")
 ```
 
 ## DNS Caching

--- a/docs/sdk/server-side-sdks/node.md
+++ b/docs/sdk/server-side-sdks/node.md
@@ -13,6 +13,13 @@ providing immediate responses to variable and feature requests for a user.
 The SDK will download the latest version of your DevCycle environments configuration from a CDN on initialization,
 and will periodically poll the CDN for configuration changes.
 
+:::
+
+The SDK is available as a package on npm. It is also open source and can be viewed on Github.
+
+[![Npm package version](https://badgen.net/npm/v/@devcycle/nodejs-server-sdk)](https://www.npmjs.com/package/@devcycle/nodejs-server-sdk)
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/js-sdks.svg?style=social&label=Star&maxAge=2592000)](https://github.com/devcyclehq/js-sdks)
+
 ## Installation
 
 Our library can be found on npm and installed by the following:

--- a/docs/sdk/server-side-sdks/node.md
+++ b/docs/sdk/server-side-sdks/node.md
@@ -13,8 +13,6 @@ providing immediate responses to variable and feature requests for a user.
 The SDK will download the latest version of your DevCycle environments configuration from a CDN on initialization,
 and will periodically poll the CDN for configuration changes.
 
-:::
-
 The SDK is available as a package on npm. It is also open source and can be viewed on Github.
 
 [![Npm package version](https://badgen.net/npm/v/@devcycle/nodejs-server-sdk)](https://www.npmjs.com/package/@devcycle/nodejs-server-sdk)

--- a/docs/sdk/server-side-sdks/php.md
+++ b/docs/sdk/server-side-sdks/php.md
@@ -7,6 +7,12 @@ sidebar_position: 2
 
 Welcome to the the DevCycle PHP SDK, initially generated via the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 
+:::
+
+The SDK is available as a package on Packagist. It is also open source and can be viewed on Github.
+[![Packagist](https://badgen.net/packagist/v/devcycle/php-server-sdk/latest)](https://packagist.org/packages/devcycle/php-server-sdk)
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/php-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/php-server-sdk)
+
 ## Requirements
 
 PHP 7.3 and later.

--- a/docs/sdk/server-side-sdks/php.md
+++ b/docs/sdk/server-side-sdks/php.md
@@ -7,9 +7,8 @@ sidebar_position: 2
 
 Welcome to the the DevCycle PHP SDK, initially generated via the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 
-:::
-
 The SDK is available as a package on Packagist. It is also open source and can be viewed on Github.
+
 [![Packagist](https://badgen.net/packagist/v/devcycle/php-server-sdk/latest)](https://packagist.org/packages/devcycle/php-server-sdk)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/php-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/php-server-sdk)
 

--- a/docs/sdk/server-side-sdks/python.md
+++ b/docs/sdk/server-side-sdks/python.md
@@ -7,9 +7,8 @@ sidebar_position: 5
 
 Welcome to the the DevCycle Python SDK, initially generated via the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 
-:::
-
 The SDK is available as a package on PyPI. It is also open source and can be viewed on Github.
+
 [![PyPI](https://badgen.net/pypi/v/devcycle-python-server-sdk)](https://pypi.org/project/devcycle-python-server-sdk/)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/python-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/python-server-sdk)
 

--- a/docs/sdk/server-side-sdks/python.md
+++ b/docs/sdk/server-side-sdks/python.md
@@ -7,6 +7,12 @@ sidebar_position: 5
 
 Welcome to the the DevCycle Python SDK, initially generated via the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 
+:::
+
+The SDK is available as a package on PyPI. It is also open source and can be viewed on Github.
+[![PyPI](https://badgen.net/pypi/v/devcycle-python-server-sdk)](https://pypi.org/project/devcycle-python-server-sdk/)
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/python-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/python-server-sdk)
+
 ## Requirements.
 
 Python 2.7 and 3.4+

--- a/docs/sdk/server-side-sdks/ruby.md
+++ b/docs/sdk/server-side-sdks/ruby.md
@@ -7,6 +7,12 @@ sidebar_position: 4
 
 Welcome to the the DevCycle Ruby SDK, initially generated via the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 
+:::
+
+The SDK is available as a package on RubyGems. It is also open source and can be viewed on Github.
+[![RubyGems](https://badgen.net/rubygems/v/devcycle-ruby-server-sdk/latest)](https://rubygems.org/gems/devcycle-ruby-server-sdk)
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/ruby-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/ruby-server-sdk)
+
 ## Installation
 
 Install the gem

--- a/docs/sdk/server-side-sdks/ruby.md
+++ b/docs/sdk/server-side-sdks/ruby.md
@@ -7,9 +7,8 @@ sidebar_position: 4
 
 Welcome to the the DevCycle Ruby SDK, initially generated via the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 
-:::
-
 The SDK is available as a package on RubyGems. It is also open source and can be viewed on Github.
+
 [![RubyGems](https://badgen.net/rubygems/v/devcycle-ruby-server-sdk/latest)](https://rubygems.org/gems/devcycle-ruby-server-sdk)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/ruby-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/ruby-server-sdk)
 


### PR DESCRIPTION
Add badges with links to Package Manager (points to latest version) and to GH with Stars on Source Repo

JS based packages on NPM (including NodeJS Server SDK and JS, React and React-Native Client SDKs):
<img width="740" alt="image" src="https://user-images.githubusercontent.com/91074031/189368319-62249348-0955-4409-9238-8992be1ed260.png">

iOS:
<img width="973" alt="image" src="https://user-images.githubusercontent.com/91074031/189368542-1c10c085-cba5-4163-97dd-fc21173dd193.png">

Java & Kotlin based packages on Maven Central (Android Client SDK and Java Server SDK):
![image](https://user-images.githubusercontent.com/91074031/189368658-91faf784-0870-4c19-b9d6-26e5799703bf.png)

PHP:
![image](https://user-images.githubusercontent.com/91074031/189368998-a811665a-4273-47bc-ad01-25ab1cf42950.png)

Ruby:
![image](https://user-images.githubusercontent.com/91074031/189369092-b392ded5-908c-4492-89b2-ace782b0b877.png)

Python:
![image](https://user-images.githubusercontent.com/91074031/189369157-f61746dd-d87e-4247-82f4-6e8f52bc54a1.png)

C# / .NET:
![image](https://user-images.githubusercontent.com/91074031/189369330-eefd0c9a-6140-4f48-b8e9-b334f7dcce99.png)
