### PR TITLE
chore: added feature section for realtime updates, clarified onUpdate

### DIFF
--- a/docs/sdk/client-side-sdks/javascript.md
+++ b/docs/sdk/client-side-sdks/javascript.md
@@ -85,7 +85,12 @@ To grab the value, there is a property on the object returned to grab the value:
 const value = variable.value
 ```
 
-If the value is not ready, it will return the default value passed in the creation of the variable. To get notified when the variable is loaded: 
+If the value is not ready, it will return the default value passed in the creation of the variable. 
+
+The `onUpdate` accepts a handler function that will be called whenever a variable value has changed.
+This can occur as a result of a project configuration change or calls to `identifyUser` or `resetUser`. To learn more, visit our [Realtime Updates](/docs/sdk/features/realtime-updates) page.
+
+There can only be one onUpdate function registered at a time. Subsequent calls to this method will overwrite the previous handler:
 
 ```javascript
 variable.onUpdate((value) => {
@@ -93,7 +98,7 @@ variable.onUpdate((value) => {
 })
 ```
 
-See [getVariableByKey](https://docs.devcycle.com/bucketing-api/#operation/getVariableByKey) on the Bucketing API for the variable response format.
+The `DVCVariable` type interface can be found [here](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/js/src/types.ts#L233).
 
 ## Identifying User
 
@@ -153,8 +158,7 @@ const variables = client.allVariables()
 
 If the SDK has not finished initializing, these methods will return an empty object.
 
-See [getVariables](https://docs.devcycle.com/bucketing-api/#operation/getVariables) and [getFeatures](https://docs.devcycle.com/bucketing-api/#operation/getFeatures) on the Bucketing API for the response formats.
-
+See [DVCVariable](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/js/src/types.ts#L233) and [DVCFeature](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/js/src/types.ts#L18) for the type interface of the variables and features returned from `allVariables()` and `allFeatures()`.
 
 ## Tracking Events
 
@@ -184,6 +188,30 @@ dvcClient.flushEvents(() => {
     // called back after flushed events
 })
 ```
+
+## Subscribing to SDK Events
+
+The SDK can emit certain events when specific actions occur which can be listened on by subscribing to them:
+
+```javascript
+dvcClient.subscribe('variableUpdated:*', (key: string, variable: DVCVariable) => {
+    // key is the variable that has been updated
+    // The new value can be accessed from the variable object passed in: variable.value
+    console.log(`New variable value for variable ${key}: ${variable.value}`)
+})
+```
+
+The first argument is the name of the event that you can subscribe to. The `subscribe` method will throw an error if you try to
+subscribe to an event that doesn't exist. These are the events you can subscribe to:
+
+| **Event**        | **Key**             | **Handler Params**                     | **Description**                                                                                                                                                                                                                                                                 |
+|------------------|---------------------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Initialized      | `initialized`       | `(initialized: boolean)`               | An initialized event is emitted once the SDK has received its first config from DevCycle. This event will only be emitted once.                                                                                                                                                         |
+| Error            | `error`             | `(error: Error)`                       | If any error occurs in the SDK, this event emits that error.                                                                                                                                                                                                                    |
+| Variable Updated | `variableUpdated:*` | `(key: string, variable: DVCVariable)` | This event gets triggered when a variable value changes for a user. You can subscribe to all variable updates using the `*` identifier, or you can pass in the key of the variable you want to subscribe to, e.g. `variableUpdated:my_variable_key`. |
+| Feature Updated  | `featureUpdated:*`  | `(key: string, feature: DVCFeature)`   | This event gets triggered when a feature's variation changes for a user. You can subscribe to all feature updates using the `*` identifier, or you can pass in the key of the feature you want to subscribe to, e.g. `featureUpdated:my_feature_key`.  |
+
+
 
 ## EdgeDB
 

--- a/docs/sdk/client-side-sdks/react-native.md
+++ b/docs/sdk/client-side-sdks/react-native.md
@@ -133,7 +133,7 @@ export default withDVCProvider({ envKey: 'ENV_KEY' })(App)
 
 ### Blocking
 
-The useIsDVCProvider hook allows you to block rendering of your application until SDK initialization is complete. This ensures your app 
+The `useIsDVCInitialized` hook allows you to block rendering of your application until SDK initialization is complete. This ensures your app 
 does not flicker due to value changes and enables you to control what you want displayed when initialization isn't finished yet.
 
 ```js

--- a/docs/sdk/client-side-sdks/react.md
+++ b/docs/sdk/client-side-sdks/react.md
@@ -63,7 +63,7 @@ export default withDVCProvider({ envKey: 'ENV_KEY' })(App)
 
 ### Blocking
 
-The useIsDVCProvider hook allows you to block rendering of your application until SDK initialization is complete. This ensures your app 
+The `useIsDVCInitialized` hook allows you to block rendering of your application until SDK initialization is complete. This ensures your app 
 does not flicker due to value changes and enables you to control what you want displayed when initialization isn't finished yet.
 
 ```js
@@ -111,6 +111,7 @@ import { asyncWithDVCProvider } from '@devcycle/devcycle-react-sdk'
 The SDK provides a hook to access your DevCycle variables:
 
 #### useVariableValue
+
 Use this hook to access the value of your DevCycle variables inside your components.
 It takes in your variable key as well as a default value and returns the value of the variable.
 
@@ -131,10 +132,11 @@ const DVCFeaturePage = () => {
     )
 }
 ```
-See [getVariableByKey](https://docs.devcycle.com/bucketing-api/#operation/getVariableByKey) on the Bucketing API for the variable response format.
 
+If a change on the dashboard triggers your variable value to change, it will rerender your page to reflect your new variable value. To learn more, visit the [Realtime Updates](/docs/sdk/features/realtime-updates) page.
 
 ### Getting the DevCycle Client
+
 The SDK provides a hook to access the underlying DevCycle client. This allows you identify users, track events, and directly access
 variables:
 
@@ -228,8 +230,7 @@ The client object can be obtained from the [useDVCClient](#getting-the-devcycle-
 
 If the SDK has not finished initializing, these methods will return an empty object.
 
-See [getVariables](https://docs.devcycle.com/bucketing-api/#operation/getVariables) and [getFeatures](https://docs.devcycle.com/bucketing-api/#operation/getFeatures) on the Bucketing API for the response formats.
-
+See [DVCVariable](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/js/src/types.ts#L233) and [DVCFeature](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/js/src/types.ts#L18) for the type interface of the variables and features returned from `allVariables()` and `allFeatures()`.
 
 ### Track Events
 Events can be tracked by calling the `track` method provided by the client object, which you can access with the

--- a/docs/sdk/features/realtime-updates.md
+++ b/docs/sdk/features/realtime-updates.md
@@ -1,0 +1,26 @@
+---
+title: Realtime Updates
+sidebar_position: 10
+---
+
+## Overview
+
+This article serves to explain how the SDKs handle realtime updates triggered by changes to your features from the DevCycle dashboard.
+
+DevCycle leverages Server-Sent Events (SSE) to notify the SDKs that their config has changed and that they should fetch a new config. When a change 
+to a feature (targeting rules, variable values, etc.) has been saved, our servers send a SSE to anyone subscribed to that project and triggers
+the SDK to request a new config from DevCycle.
+
+### Client-Side SDK
+
+A connection URL is included in the config that the SDK fetches, triggering the SDK to open a connection with our SSE provider listening
+for any changes from the dashboard.
+
+The following Client-Side SDKs currently have Realtime Updates:
+
+- Javascript SDK
+- React SDK
+
+#### **Javascript SDK** & **React SDK**
+
+If the user loses focus on the webpage, the SDK will disconnect from the SSE provider and will reconnect when the user opens the tab / window again (i.e. the page's visibility state = `visible`). The SDK will also request a new configuration during reconnection to receive any updates it may have missed while the realtime connection was closed.


### PR DESCRIPTION
# Changes

- Clarified `onUpdate` usage and when it triggers
- Added section to JS SDK on what events can be subscribed to
- Added section in Features on Realtime Updates