### PR TITLE
DVC-6885 [fix]: update Client SDKs with disableRealtimeUpdates initialization option

### DIFF
--- a/docs/sdk/client-side-sdks/android.md
+++ b/docs/sdk/client-side-sdks/android.md
@@ -135,6 +135,7 @@ The SDK exposes various initialization options which can be used by passing a `D
 | enableEdgeDB | Boolean | false | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. |
 | configCacheTTL | Long | 604800000 | The maximum allowed age of a cached config in milliseconds, defaults to 7 days |
 | disableConfigCache | Boolean | false | Disable the use of cached configs |
+| disableRealtimeUpdates | Boolean | false | Disable Realtime Updates |
 
 ### Notifying when DevCycle features are available
 

--- a/docs/sdk/client-side-sdks/flutter.md
+++ b/docs/sdk/client-side-sdks/flutter.md
@@ -118,6 +118,7 @@ The SDK exposes various initialization options which can be used by passing a `D
 | enableEdgeDB | Boolean | false | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. |
 | configCacheTTL | Int | 604800000 | The maximum allowed age of a cached config in milliseconds, defaults to 7 days |
 | disableConfigCache | Bool | false | Disable the use of cached configs |
+| disableRealtimeUpdates | Bool | false | Disable Realtime Updates |
 
 ### Notifying when DevCycle features are available
 

--- a/docs/sdk/client-side-sdks/ios.md
+++ b/docs/sdk/client-side-sdks/ios.md
@@ -170,6 +170,7 @@ The SDK exposes various initialization options which can be used by passing a `D
 | enableEdgeDB | Boolean | false | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. |
 | configCacheTTL | Int | 604800000 | The maximum allowed age of a cached config in milliseconds, defaults to 7 days |
 | disableConfigCache | Bool | false | Disable the use of cached configs |
+| disableRealtimeUpdates | Bool | false | Disable Realtime Updates |
 
 ### Notifying when DevCycle features are available
 

--- a/docs/sdk/client-side-sdks/javascript.md
+++ b/docs/sdk/client-side-sdks/javascript.md
@@ -86,13 +86,16 @@ The SDK exposes various initialization options which can be set on the `initiali
 
 [DVCOptions Typescript Schema](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/js/src/types.ts#L44)
 
-| DVC Option           | Type                                                                                                     | Description                                                                                                    |
-| -------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| eventFlushIntervalMS | number                                                                                                   | Controls the interval between flushing events to the DevCycle servers in milliseconds, defaults to 10 seconds. |
-| enableEdgeDB         | boolean                                                                                                  | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle.                                     |
-| logger               | [DVCLogger](https://github.com/DevCycleHQ/js-sdks/blob/main/lib/shared/types/src/logger.ts#L2)           | Logger override to replace default logger                                                                      |
-| logLevel             | [DVCDefaultLogLevel](https://github.com/DevCycleHQ/js-sdks/blob/main/lib/shared/types/src/logger.ts#L12) | Set log level of the default logger. Options are: `debug`, `info`, `warn`, `error`. Defaults to `info`.        |
-| apiProxyURL          | string                                                                                                   | Allows the SDK to communicate with a proxy of DVC bucketing API / client SDK API.                              |
+| DVC Option             | Type                                                                                                     | Description                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| eventFlushIntervalMS   | number                                                                                                   | Controls the interval between flushing events to the DevCycle servers in milliseconds, defaults to 10 seconds. |
+| enableEdgeDB           | boolean                                                                                                  | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle.                                     |
+| logger                 | [DVCLogger](https://github.com/DevCycleHQ/js-sdks/blob/main/lib/shared/types/src/logger.ts#L2)           | Logger override to replace default logger                                                                      |
+| logLevel               | [DVCDefaultLogLevel](https://github.com/DevCycleHQ/js-sdks/blob/main/lib/shared/types/src/logger.ts#L12) | Set log level of the default logger. Options are: `debug`, `info`, `warn`, `error`. Defaults to `info`.        |
+| apiProxyURL            | string                                                                                                   | Allows the SDK to communicate with a proxy of DVC bucketing API / client SDK API.                              |
+| configCacheTTL         | number                                                                                                   | The maximum allowed age of a cached config in milliseconds, defaults to 7 days                                 |
+| disableConfigCache     | boolean                                                                                                  | Disable the use of cached configs                                                                              |
+| disableRealtimeUpdates | boolean                                                                                                  | Disable Realtime Updates                                                                                       |
 
 ## Waiting for Features
 

--- a/docs/sdk/client-side-sdks/react-native.md
+++ b/docs/sdk/client-side-sdks/react-native.md
@@ -106,6 +106,35 @@ function App() {
 export default withDVCProvider({ sdkKey: '<DVC_CLIENT_SDK_KEY>' })(App)
 ```
 
+### Provider Config
+
+The `withDVCProvider` function accepts a Provider Config object:
+
+[DVC ProviderConfig Typescript Schema](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/react/src/types.ts#L3)
+
+| Property | Type | Description            |
+|------------|------|------------------------|
+| sdkKey | string | SDK key                |
+| user | [DVCUser](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/js/src/types.ts#L55) | DevCycle user object   |
+| options | [DVCOptions](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/js/src/types.ts#L44) | DevCycle options object |
+
+### Initialization Options
+
+The SDK exposes various initialization options which can be set by passing a `DVCOptions` object in the Provider Config:
+
+[DVCOptions Typescript Schema](https://github.com/DevCycleHQ/js-sdks/blob/main/sdk/js/src/types.ts#L44)
+
+| DVC Option | Type | Description |
+|------------|------|-------------|
+| eventFlushIntervalMS | number | Controls the interval between flushing events to the DevCycle servers in milliseconds, defaults to 10 seconds. |
+| enableEdgeDB | boolean | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. |
+| logger | [DVCLogger](https://github.com/DevCycleHQ/js-sdks/blob/main/lib/shared/types/src/logger.ts#L2) | Logger override to replace default logger |
+| logLevel | [DVCDefaultLogLevel](https://github.com/DevCycleHQ/js-sdks/blob/main/lib/shared/types/src/logger.ts#L12) | Set log level of the default logger. Options are: `debug`, `info`, `warn`, `error`. Defaults to `info`. |
+| apiProxyURL | string | Allows the SDK to communicate with a proxy of DVC bucketing API / client SDK API. |
+| configCacheTTL | number | The maximum allowed age of a cached config in milliseconds, defaults to 7 days |
+| disableConfigCache | boolean | Disable the use of cached configs |
+| disableRealtimeUpdates | boolean | Disable Realtime Updates |
+
 ## Getting Started
 
 There are two ways to initialize the SDK:

--- a/docs/sdk/client-side-sdks/react.md
+++ b/docs/sdk/client-side-sdks/react.md
@@ -150,6 +150,7 @@ The SDK exposes various initialization options which can be set by passing a `DV
 | apiProxyURL | string | Allows the SDK to communicate with a proxy of DVC bucketing API / client SDK API. |
 | configCacheTTL | number | The maximum allowed age of a cached config in milliseconds, defaults to 7 days |
 | disableConfigCache | boolean | Disable the use of cached configs |
+| disableRealtimeUpdates | boolean | Disable Realtime Updates |
 
 ### Getting a Variable
 


### PR DESCRIPTION
- To Merge once iOS, Android and Flutter SDKs are published