### PR TITLE
[chore] split go sdk docs into individual pages

### DIFF
--- a/docs/home/feature-management/edgedb/edge-flags.md
+++ b/docs/home/feature-management/edgedb/edge-flags.md
@@ -85,8 +85,8 @@ For specific documentation on how to use Edge Flags with each SDK
 - [React Native](/sdk/client-side-sdks/react-native/react-native-usage#edgedb)
 
 #### Server SDKs
-- [Go SDK](/sdk/server-side-sdks/go#edgedb)
-- [Java SDK](/sdk/server-side-sdks/java-cloud/java-cloud-usage#edgedb)
+- [Go SDK](/sdk/server-side-sdks/go/go-usage#edgedb)
+- [Java SDK](/sdk/server-side-sdks/java-cloud#edgedb)
 - [Node.js SDK](/sdk/server-side-sdks/node#edgedb)
 - [PHP SDK](/sdk/server-side-sdks/php/php-usage#edgedb)
 - [Python SDK](/sdk/server-side-sdks/python/python-usage#edgedb)

--- a/docs/sdk/example-apps.md
+++ b/docs/sdk/example-apps.md
@@ -15,7 +15,7 @@ Welcome to the Samples & Example Apps page, which showcases example applications
 | [.NET (Local Bucketing)](https://github.com/DevCycleHQ/dotnet-server-sdk) | [.NET (Local Bucketing) Reference Docs](/sdk/server-side-sdks/dotnet-local.md) |
 | [Android](https://github.com/DevCycleHQ/android-client-sdk)               | [Android Reference Docs](/sdk/client-side-sdks/android/android.md)                     |
 | [Flutter](https://github.com/devcyclehq/flutter-client-sdk)               | [Flutter Reference Docs](/sdk/client-side-sdks/flutter/flutter.md)                     |
-| [Go](https://github.com/DevCycleHQ/go-server-sdk)                         | [Go Reference Docs](/sdk/server-side-sdks/go.md)                               |
+| [Go](https://github.com/DevCycleHQ/go-server-sdk)                         | [Go Reference Docs](/sdk/server-side-sdks/go/go.md)                               |
 | [iOS](https://github.com/devcyclehq/ios-client-sdk)                       | [iOS Reference Docs](/sdk/client-side-sdks/ios/ios.md)                             |
 | [Java (Cloud Bucketing)](https://github.com/DevCycleHQ/java-server-sdk)   | [Java (Cloud Bucketing) Reference Docs](/sdk/server-side-sdks/java-cloud/java-cloud.md)   |
 | [Java (Local Bucketing)](https://github.com/DevCycleHQ/java-server-sdk)   | [Java (Local Bucketing) Reference Docs](/sdk/server-side-sdks/java-local/java-local.md)   |

--- a/docs/sdk/features/all-features.md
+++ b/docs/sdk/features/all-features.md
@@ -61,7 +61,7 @@ The DevCycle React SDK is built upon the JavaScript SDK. For more details, view 
 
 ### [• NodeJS SDK (server-side)](/sdk/server-side-sdks/node#getting-all-features)
 
-### [• Go SDK](/sdk/server-side-sdks/go#getting-all-features)
+### [• Go SDK](/sdk/server-side-sdks/go/go-usage#getting-all-features)
 
 ### [• Ruby SDK](/sdk/server-side-sdks/ruby/ruby-usage#getting-all-features)
 

--- a/docs/sdk/features/all-variables.md
+++ b/docs/sdk/features/all-variables.md
@@ -61,7 +61,7 @@ The DevCycle React SDK is built upon the JavaScript SDK. For more details, view 
 
 ### [• NodeJS SDK (server-side)](/sdk/server-side-sdks/node#getting-all-variables)
 
-### [• Go SDK](/sdk/server-side-sdks/go#getting-all-variables)
+### [• Go SDK](/sdk/server-side-sdks/go/go-usage#getting-all-variables)
 
 ### [• Ruby SDK](/sdk/server-side-sdks/ruby/ruby-usage#getting-all-variables)
 

--- a/docs/sdk/features/evaluating.md
+++ b/docs/sdk/features/evaluating.md
@@ -31,7 +31,7 @@ If there is an error reaching DevCycle, if the requested variable does not exist
 
 ### [• C# / .NET Cloud SDK](/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-usage#get-and-use-variable-by-key)
 
-### [• Go SDK](/sdk/server-side-sdks/go#get-and-use-variable-by-key)
+### [• Go SDK](/sdk/server-side-sdks/go/go-usage#get-and-use-variable-by-key)
 
 ### [• Python SDK](/sdk/server-side-sdks/python/python-usage#get-and-use-variable-by-key)
 

--- a/docs/sdk/features/identify.md
+++ b/docs/sdk/features/identify.md
@@ -93,7 +93,7 @@ As well, unlike the Client-Side SDKs, because Server-Side SDKs poll for project 
 
 ### [• C# / .NET Cloud SDK](/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-usage#user-object)
 
-### [• Go SDK](/sdk/server-side-sdks/go#user-object)
+### [• Go SDK](/sdk/server-side-sdks/go/go-usage#user-object)
 
 ### [• Python SDK](/sdk/server-side-sdks/python/python-gettingstarted#user-object)
 

--- a/docs/sdk/features/initialization.md
+++ b/docs/sdk/features/initialization.md
@@ -41,7 +41,7 @@ If a variable is first read from the cache and has a listener for [realtime upda
 
 ### [• C# / .NET Cloud SDK](/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-gettingstarted)
 
-### [• Go SDK](/sdk/server-side-sdks/go#installation)
+### [• Go SDK](/sdk/server-side-sdks/go/go-gettingstarted)
 
 ### [• Python SDK](/sdk/server-side-sdks/python/python-gettingstarted)
 

--- a/docs/sdk/features/track.md
+++ b/docs/sdk/features/track.md
@@ -35,7 +35,7 @@ The Track function in the DevCycle SDKs allows you to send up custom events whic
 
 ### [• C# / .NET Cloud SDK](/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-usage#track-event)
 
-### [• Go SDK](/sdk/server-side-sdks/go#tracking-user-event)
+### [• Go SDK](/sdk/server-side-sdks/go/go-usage#tracking-user-event)
 
 ### [• Python SDK](/sdk/server-side-sdks/python/python-usage#track-event)
 

--- a/docs/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-gettingstarted.md
@@ -7,6 +7,8 @@ sidebar_position: 2
 [![Nuget](https://badgen.net/nuget/v/DevCycle.SDK.Server.Cloud)](https://www.nuget.org/packages/DevCycle.SDK.Server.Cloud/)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/dotnet-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/dotnet-server-sdk)
 
+## Initializing SDK 
+
 To start, initialize a client using the API key. 
 
 ```csharp

--- a/docs/sdk/server-side-sdks/go/_category_.yml
+++ b/docs/sdk/server-side-sdks/go/_category_.yml
@@ -1,0 +1,2 @@
+position: 3
+collapsed: true

--- a/docs/sdk/server-side-sdks/go/go-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/go/go-gettingstarted.md
@@ -1,0 +1,53 @@
+---
+title: DevCycle Go Server SDK Getting Started
+sidebar_label: Getting Started
+sidebar_position: 2
+---
+
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/go-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/go-server-sdk)
+
+## Initializing SDK 
+
+When initializing the Go SDK, you can choose to use `Cloud` or `Local` bucketing. The default mode is `Local`.
+To use `Cloud` bucketing, set the DVCOptions setting `EnableCloudBucketing` to true.
+
+```go
+package main 
+
+import (
+"github.com/devcyclehq/go-server-sdk/v2"
+"context"
+)
+
+func main() {
+    sdkKey := os.Getenv("<DVC_SERVER_SDK_KEY>")
+    user := devcycle.UserData{UserId: "test"}
+    onInitializedChannel := make(chan bool) // optional
+ 
+    dvcOptions := devcycle.DVCOptions{
+        EnableEdgeDB:                 false,
+        EnableCloudBucketing:         false,
+        EventFlushIntervalMS:         0,
+        ConfigPollingIntervalMS:      10 * time.Second,
+        RequestTimeout:               10 * time.Second,
+        DisableAutomaticEventLogging: false,
+        DisableCustomEventLogging:    false,
+        OnInitializedChannel:         onInitializedChannel,
+    }
+    
+    client, err := devcycle.NewDVCClient(sdkKey, &dvcOptions)
+}
+```
+
+If using local bucketing, be sure to check the error return from creating a new DVCClient - if the local bucketing engine fails to
+initialize for any reason- it'll return as an error here.
+Additionally, local bucketing mode supports an optional `OnInitializedChannel` parameter which will tell the sdk to run the initialization
+process in a separate go routine. When the channel receives a message, you will know the initialization process is complete.
+
+```go
+client, err := devcycle.NewDVCClient(sdkKey, &dvcOptions)
+log.Println("client not guaranteed to be initialized yet")
+<-onInitializedChannel
+log.Println("Devcycle client initialized")
+```
+

--- a/docs/sdk/server-side-sdks/go/go-install.md
+++ b/docs/sdk/server-side-sdks/go/go-install.md
@@ -1,0 +1,18 @@
+---
+title: DevCycle Go Server SDK Installation
+sidebar_label: Installation
+sidebar_position: 1
+---
+
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/go-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/go-server-sdk)
+
+```bash
+go get "github.com/devcyclehq/go-server-sdk/v2"
+```
+
+:::note
+
+The DevCycle Go Server SDK requires [cgo](https://pkg.go.dev/cmd/cgo) to be enabled in your build in order to function. 
+
+:::
+

--- a/docs/sdk/server-side-sdks/go/go-usage.md
+++ b/docs/sdk/server-side-sdks/go/go-usage.md
@@ -1,79 +1,12 @@
 ---
-title: Go SDK
+title: DevCycle Go Server SDK Usage
+sidebar_label: Usage
 sidebar_position: 3
 ---
 
-# DevCycle Go Server SDK.
-
-Welcome to the DevCycle Go SDK. We have two modes for the SDK. Cloud bucketing (using
-the [Bucketing API](https://bucketing-api.devcycle.com))
-and Local Bucketing (using the local bucketing engine natively within the SDK).
-The SDK is open source and can be viewed on GitHub.
-
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/go-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/go-server-sdk)
 
-## Installation
-
-```bash
-go get "github.com/devcyclehq/go-server-sdk/v2"
-```
-
-:::note
-
-The DevCycle Go Server SDK requires [cgo](https://pkg.go.dev/cmd/cgo) to be enabled in your build in order to function. 
-
-:::
-
-
-## Getting Started
-
-When initializing the Go SDK, you can choose to use `Cloud` or `Local` bucketing. The default mode is `Local`.
-To use `Cloud` bucketing, set the DVCOptions setting `EnableCloudBucketing` to true.
-
-```go
-package main 
-
-import (
-"github.com/devcyclehq/go-server-sdk/v2"
-"context"
-)
-
-func main() {
-    sdkKey := os.Getenv("<DVC_SERVER_SDK_KEY>")
-    user := devcycle.UserData{UserId: "test"}
-    onInitializedChannel := make(chan bool) // optional
- 
-    dvcOptions := devcycle.DVCOptions{
-        EnableEdgeDB:                 false,
-        EnableCloudBucketing:         false,
-        EventFlushIntervalMS:         0,
-        ConfigPollingIntervalMS:      10 * time.Second,
-        RequestTimeout:               10 * time.Second,
-        DisableAutomaticEventLogging: false,
-        DisableCustomEventLogging:    false,
-        OnInitializedChannel:         onInitializedChannel,
-    }
-    
-    client, err := devcycle.NewDVCClient(sdkKey, &dvcOptions)
-}
-```
-
-If using local bucketing, be sure to check the error return from creating a new DVCClient - if the local bucketing engine fails to
-initialize for any reason- it'll return as an error here.
-Additionally, local bucketing mode supports an optional `OnInitializedChannel` parameter which will tell the sdk to run the initialization
-process in a separate go routine. When the channel receives a message, you will know the initialization process is complete.
-
-```go
-client, err := devcycle.NewDVCClient(sdkKey, &dvcOptions)
-log.Println("client not guaranteed to be initialized yet")
-<-onInitializedChannel
-log.Println("Devcycle client initialized")
-```
-
-
-## Usage
-
-### User Object
+## User Object
 
 The user object is required for all methods. This is the basis of how segmentation and bucketing decisions are made. 
 The only required field in the user object is UserId
@@ -84,7 +17,7 @@ See the UserData class in `model_user_data.go` for all accepted fields.
 user := devcycle.UserData{UserId: "test"}
 ```
 
-### Getting All Features
+## Getting All Features
 
 This method will fetch all features for a given user and return them in a map of `key: feature_object`
 
@@ -94,7 +27,7 @@ features, err := client.AllFeatures(user)
 
 Local Bucketing will return an error if there was a problem either
 
-### Getting All Variables
+## Getting All Variables
 
 To get values from your Variables, the `value` field inside the variable object can be accessed.
 
@@ -104,7 +37,7 @@ This method will fetch all variables for a given user and return them in a map o
 variables, err := client.AllVariables(user)
 ```
 
-### Get and Use Variable by Key
+## Get and Use Variable by Key
 
 This method will fetch a specific variable by key for a given user. It will return the variable
 object from the server unless an error occurs or the server has no response. In that case it will return
@@ -124,7 +57,7 @@ eg.
 
 `variable.Value.(string)` for the above example
 
-### Track Event
+## Track Event
 
 To POST custom event for a user, pass in the user and event object.
 
@@ -138,7 +71,7 @@ Target: "somevariable.key"}
 response, err := client.Track(user, event)
 ```
 
-### Close
+## Close
 
 You can close the DevCycle client to stop the SDK from polling for configs and flushing events on an interval. Any pending events will be immediately flushed.
 Only usable in local bucketing mode.
@@ -147,7 +80,7 @@ Only usable in local bucketing mode.
 err := client.Close()
 ```
 
-### EdgeDB
+## EdgeDB
 
 EdgeDB allows you to save user data to our EdgeDB storage so that you don't have to pass in all the user data every time
 you identify a user. Read more about [EdgeDB](/home/feature-management/edgedb/what-is-edgedb).

--- a/docs/sdk/server-side-sdks/go/go.md
+++ b/docs/sdk/server-side-sdks/go/go.md
@@ -1,0 +1,14 @@
+---
+title: Go SDK
+---
+
+# DevCycle Go Server SDK.
+
+Welcome to the DevCycle Go SDK. We have two modes for the SDK. Cloud bucketing (using
+the [Bucketing API](https://bucketing-api.devcycle.com))
+and Local Bucketing (using the local bucketing engine natively within the SDK).
+The SDK is open source and can be viewed on GitHub.
+
+[![GitHub](https://img.shields.io/github/stars/devcyclehq/go-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/go-server-sdk)
+
+

--- a/docs/sdk/server-side-sdks/php/php-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/php/php-gettingstarted.md
@@ -10,6 +10,8 @@ sidebar_position: 2
 
 Please follow the [installation procedure](/sdk/server-side-sdks/php/php-install) and then run the following:
 
+## Initializing SDK 
+
 ```php
 <?php
 require_once(__DIR__ . '/vendor/autoload.php');

--- a/docs/sdk/server-side-sdks/python/python-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/python/python-gettingstarted.md
@@ -6,6 +6,8 @@ sidebar_position: 2
 [![PyPI](https://badgen.net/pypi/v/devcycle-python-server-sdk)](https://pypi.org/project/devcycle-python-server-sdk/)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/python-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/python-server-sdk)
 
+## Initializing SDK 
+
 Code sample for importing and setting up the DVCClient.
 
 ```python


### PR DESCRIPTION
- fix other urls in initialize to direct to gettingstarted instead of install page