### PR TITLE
fix anchors on CLI page

### DIFF
--- a/docs/sdk/client-side-sdks/javascript/javascript-typescript.md
+++ b/docs/sdk/client-side-sdks/javascript/javascript-typescript.md
@@ -64,7 +64,7 @@ To generate the type definitions with the CLI, you can use the `generate types` 
 dvc generate types
 ```
 
-See the [documentation](https://docs.devcycle.com/tools-and-integrations/cli#dvc-generate-types) for this command
+See the [documentation](https://github.com/DevCycleHQ/cli/blob/main/docs/generate.md#dvc-generate-types) for this command
 
 Ensure that the CLI is properly setup and authenticated to your project before running this command. See the [CLI docs](https://docs.devcycle.com/tools-and-integrations/cli)
 for further instructions on setting up the CLI.

--- a/docs/sdk/client-side-sdks/react/react-typescript.md
+++ b/docs/sdk/client-side-sdks/react/react-typescript.md
@@ -48,7 +48,7 @@ To generate the type definitions with the CLI, you can use the `generate types` 
 dvc generate types --react
 ```
 
-See the [documentation](https://docs.devcycle.com/tools-and-integrations/cli#dvc-generate-types) for this command
+See the [documentation](https://github.com/DevCycleHQ/cli/blob/main/docs/generate.md#dvc-generate-types) for this command
 
 Ensure that the CLI is properly setup and authenticated to your project before running this command. See the [CLI docs](https://docs.devcycle.com/tools-and-integrations/cli)
 for further instructions on setting up the CLI.

--- a/docs/tools-and-integrations/cli.md
+++ b/docs/tools-and-integrations/cli.md
@@ -22,15 +22,15 @@ The CLI can be customized in several ways using command-line args or by creating
 * [Command Topics](#command-topics)
 * [Repo Configuration](#repo-configuration)
 <!-- tocstop -->
-# Setup
-## Install the CLI:
+## Setup
+### Install the CLI:
 ```sh-session
 $ npm install -g @devcycle/cli
 ```
-# Authentication
+## Authentication
 Many of the CLI commands require DevCycle API authorization. There are several ways to provide these credentials.
-## Using Access Tokens
-### Login Command (preferred)
+### Using Access Tokens
+#### Login Command (preferred)
 By using the [`login sso` command](https://github.com/DevCycleHQ/cli/blob/main/docs/login.md#dvc-login-sso), the CLI will retrieve and store an access token, which is valid for 24 hours.
 
 The [`login again` command](https://github.com/DevCycleHQ/cli/blob/main/docs/login.md#dvc-login-again) can be used to retrieve a new access token using the saved project and organization without prompting for them.
@@ -38,10 +38,10 @@ The [`login again` command](https://github.com/DevCycleHQ/cli/blob/main/docs/log
 This process will open browser windows to interact with the DevCycle universal login page. It will first obtain a personal access token, then prompt you to choose an organization. A second browser window is used to authenticate the CLI with your chosen organization.
 
 To switch organizations once logged in, the [`org` command](https://github.com/DevCycleHQ/cli/blob/main/docs/org.md) can be used.
-### Repo Init Command (preferred)
+#### Repo Init Command (preferred)
 The [`repo init` command](https://github.com/DevCycleHQ/cli/blob/main/docs/repo.md#dvc-repo-init) behaves in the same way as `login sso`, but creates a [repo configuration file](#repo-configuration) and stores the project and organization choices there instead.
-## Using Client Credentials
-### Client Credentials in Auth File
+### Using Client Credentials
+#### Client Credentials in Auth File
 Use the [`dvc status` command](https://github.com/DevCycleHQ/cli/blob/main/docs/status.md#dvc-status) to find the configuration file location for your platform. The credentials can be stored in the file pointed to by the Auth config path. Create the file if it does not exist, with the following contents.
 
 ```yaml
@@ -54,7 +54,7 @@ This file should **not** be checked in to version control.
 The default location is based on the [oclif configDir](https://oclif.io/docs/config)
 
 If you intend to run the CLI using options that override config file locations, the [`dvc status` command](https://github.com/DevCycleHQ/cli/blob/main/docs/status.md#dvc-status) command can be run with those options to confirm that the file locations are as expected.
-## Project Selection
+### Project Selection
 
 You also need to specify the default project ID for the CLI to use.
 
@@ -62,21 +62,21 @@ If there is a repo configuration file, the [`dvc diff`](https://github.com/DevCy
 
 Otherwise, this is chosen during login or set using the [project select command](https://github.com/DevCycleHQ/cli/blob/main/docs/projects.md#dvc-projects-select)
 
-### Environment Variables
+#### Environment Variables
 Set the following environment variables:
 ```sh-session
 $ export DVC_CLIENT_ID=<your client id>
 $ export DVC_CLIENT_SECRET=<your client secret>
 $ export DVC_PROJECT_KEY=<your project key>
 ```
-### Command-Line Arguments
+#### Command-Line Arguments
 The CLI can be run with the following arguments:
 ```sh-session
 $ dvc --client-id=<your client id> --client-secret=<your client secret> --project=<your project key>
 ```
-### Github Action
+#### Github Action
 The Devcycle Github actions are configured with auth information through the `project-key`, `client-id` and `client-secret` configuration parameters. This is passed to the CLI via command line arguments.
-# Usage
+## Usage
 <!-- usage -->
 ```sh-session
 $ npm install -g @devcycle/cli
@@ -90,9 +90,9 @@ USAGE
 ...
 ```
 <!-- usagestop -->
-# Commands
+## Commands
 <!-- commands -->
-# Command Topics
+## Command Topics
 
 * [`dvc alias`](https://github.com/DevCycleHQ/cli/blob/main/docs/alias.md) - Manage repository variable aliases
 * [`dvc cleanup`](https://github.com/DevCycleHQ/cli/blob/main/docs/cleanup.md) - Replace a DevCycle variable with a static value in the current version of your code. Currently only JavaScript is supported.
@@ -112,7 +112,7 @@ USAGE
 * [`dvc variables`](https://github.com/DevCycleHQ/cli/blob/main/docs/variables.md) - Access or modify Variables with the Management API
 
 <!-- commandsstop -->
-# Repo Configuration
+## Repo Configuration
 The following commands can only be run from the root of a configured repository
 * [`dvc diff`](https://github.com/DevCycleHQ/cli/blob/main/docs/diff.md)
 * [`dvc usages`](https://github.com/DevCycleHQ/cli/blob/main/docs/usages.md)

--- a/docs/tools-and-integrations/cli.md
+++ b/docs/tools-and-integrations/cli.md
@@ -29,8 +29,8 @@ $ npm install -g @devcycle/cli
 ```
 ## Authentication
 Many of the CLI commands require DevCycle API authorization. There are several ways to provide these credentials.
-### Using Access Tokens
-#### Login Command (preferred)
+### Using Access Tokens (preferred)
+#### Login Command
 By using the [`login sso` command](https://github.com/DevCycleHQ/cli/blob/main/docs/login.md#dvc-login-sso), the CLI will retrieve and store an access token, which is valid for 24 hours.
 
 The [`login again` command](https://github.com/DevCycleHQ/cli/blob/main/docs/login.md#dvc-login-again) can be used to retrieve a new access token using the saved project and organization without prompting for them.
@@ -38,7 +38,7 @@ The [`login again` command](https://github.com/DevCycleHQ/cli/blob/main/docs/log
 This process will open browser windows to interact with the DevCycle universal login page. It will first obtain a personal access token, then prompt you to choose an organization. A second browser window is used to authenticate the CLI with your chosen organization.
 
 To switch organizations once logged in, the [`org` command](https://github.com/DevCycleHQ/cli/blob/main/docs/org.md) can be used.
-#### Repo Init Command (preferred)
+#### Repo Init Command
 The [`repo init` command](https://github.com/DevCycleHQ/cli/blob/main/docs/repo.md#dvc-repo-init) behaves in the same way as `login sso`, but creates a [repo configuration file](#repo-configuration) and stores the project and organization choices there instead.
 ### Using Client Credentials
 #### Client Credentials in Auth File


### PR DESCRIPTION
Seems like markdown titles need to be (##) in order to be clickable in the sidebar