### PR TITLE
back to react 17 with new plugin update

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "docusaurus start"
   },
   "dependencies": {
-    "@devcycle/docusaurus-devcycle-plugin": "^0.0.0-rc.5",
+    "@devcycle/docusaurus-devcycle-plugin": "^0.0.0-rc.6",
     "@docusaurus/core": "^2.4.1",
     "@docusaurus/plugin-content-docs": "^2.4.1",
     "@docusaurus/preset-classic": "^2.4.1",
@@ -34,15 +34,15 @@
     "postcss-import": "^14.0.2",
     "postcss-preset-env": "^7.0.0",
     "prism": "^4.1.2",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "redocusaurus": "^1.0.1",
     "remark-docusaurus-tabs": "^0.2.0",
     "tailwindcss": "^3.0.0",
     "vercel": "^30.1.2"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0"
+    "@types/react": "^17.0.2"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,10 +1926,10 @@
     "@devcycle/types" "1.1.3"
     hoist-non-react-statics "^3.3.2"
 
-"@devcycle/docusaurus-devcycle-plugin@^0.0.0-rc.5":
-  version "0.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@devcycle/docusaurus-devcycle-plugin/-/docusaurus-devcycle-plugin-0.0.0-rc.5.tgz#9e53f08a988258f90af8aca700d88be8cceb17d7"
-  integrity sha512-vZIbSEtrI9TBEzWWL8hvXe66bBR55ZFnfB0QhJY2PEdOKntBKszIkjqNfzyN7PLwxdgfn6Pw25B+KKaNGt5nWw==
+"@devcycle/docusaurus-devcycle-plugin@^0.0.0-rc.6":
+  version "0.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@devcycle/docusaurus-devcycle-plugin/-/docusaurus-devcycle-plugin-0.0.0-rc.6.tgz#244f255ce15b3753ac347d6770b31dae45896239"
+  integrity sha512-llZEx9weZPPs2Sw3SgxoaocjLzb/Ygo29KkSaiRnDvH/3PMWuXH1La5N3SqFwEft+nH3IV/y4pCGrM9mHE58Xw==
   dependencies:
     "@devcycle/devcycle-js-sdk" "1.11.1"
     "@devcycle/devcycle-react-sdk" "1.9.4"
@@ -3532,10 +3532,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@^18.0.0":
-  version "18.2.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.8.tgz#a77dcffe4e9af148ca4aa8000c51a1e8ed99e2c8"
-  integrity sha512-lTyWUNrd8ntVkqycEEplasWy2OxNlShj3zqS0LuB1ENUGis5HodmhM7DtCoUGbxj3VW/WsGA0DUhpG6XrM7gPA==
+"@types/react@^17.0.2":
+  version "17.0.60"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.60.tgz#a4a97dcdbebad76612c188fc06440e4995fd8ad2"
+  integrity sha512-pCH7bqWIfzHs3D+PDs3O/COCQJka+Kcw3RnO9rFA2zalqoXg7cNjJDh6mZ7oRtY1wmY4LVwDdAbA1F7Z8tv3BQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -10384,13 +10384,14 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-react-dom@^18.0.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.23.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
 
 react-error-overlay@^6.0.11:
   version "6.0.11"
@@ -10497,12 +10498,13 @@ react-textarea-autosize@^8.3.2:
     use-composed-ref "^1.3.0"
     use-latest "^1.2.1"
 
-react@^18.0.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -10999,12 +11001,13 @@ sax@^1.2.4:
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
-  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 schema-utils@2.7.0:
   version "2.7.0"


### PR DESCRIPTION
Docusaurus plugin required react 18 since our sdks do (react 17 had a bug), but docusaurus doesn't officially support 18 until version 3. So an update to the plugin allows it to work with react 17, meaning this will be easier for users to install without having to bump react to 18 and seeing dev warnings.