### PR TITLE
adding references to setClientCustomData

### DIFF
--- a/docs/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-gettingstarted.md
@@ -26,7 +26,7 @@ namespace Example
         public void main()
         {
             // using ensures REST Client resources are correctly disposed once no longer required.
-            using DVCCloudClient dvcClient = new DVCCloudClientBuilder()
+            using DVCCloudClient client = new DVCCloudClientBuilder()
                 .SetSDKKey("<DVC_SERVER_SDK_KEY>")
                 .Build();
         }

--- a/docs/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-usage.md
+++ b/docs/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-usage.md
@@ -25,30 +25,7 @@ value from the server unless an error occurs or the server has no response.
 In that case it will return a variable value with the value set to whatever was passed in as the `defaultValue` parameter.
 
 ```csharp
-using System;
-using System.Diagnostics;
-using DevCycle.SDK.Server.Cloud.Api;
-using DevCycle.SDK.Server.Common.Model;
-using DevCycle.SDK.Server.Common.Model.Cloud;
-
-namespace Example {
-    public class VariableExample {
-        public void main() {
-            // Ensure REST Client resources are correctly disposed once no longer required
-            using DVCCloudClient dvcClient = new DVCCloudClientBuilder()
-                .SetSDKKey("<DVC_SERVER_SDK_KEY>")
-                .Build();
-            var user = new User("user_id");
-
-            try {
-                Boolean result = await dvcClient.VariableValueAsync(user, "YOUR_KEY", true);
-                Debug.WriteLine(result);
-            } catch (Exception e) {
-                Debug.Print("Exception when calling dvcClient.VariableValueAsync: " + e.Message);
-            }
-        }
-    }
-}
+Boolean result = await client.VariableValueAsync(user, "YOUR_KEY", true);
 ```
 
 The default value can be of type `String`, `Boolean`, `Number`, or `Object`.
@@ -63,85 +40,26 @@ To get values from your Variables, the `value` field inside the variable object 
 This method will fetch all variables for a given user and return as DictionaryString, Feature;
 
 ```csharp
-namespace Example {
-    public class AllVariablesExample {
-        public void main() {
-            // Ensure REST Client resources are correctly disposed once no longer required
-            using DVCCloudClient dvcClient = new DVCCloudClientBuilder()
-                .SetSDKKey("<DVC_SERVER_SDK_KEY>")
-                .Build();
-            var user = new User("user_id"); 
-
-            try {
-                Dictionary<string, IVariable> result = await dvcClient.AllVariablesAsync(user);
-
-                foreach (var keyValuePair in result) {
-                    // Casting to use the cloud specific variable features.
-                    Debug.WriteLine($"{keyValuePair.Key} : {(Variable)keyValuePair.Value}");
-                }
-            } catch (Exception e) {
-                Debug.Print("Exception when calling dvcClient.AllVariablesAsync: " + e.Message);
-            }
-        }
-    }
-}
+Dictionary<string, IVariable> result = await client.AllVariablesAsync(user);
 ```
 
 ## Getting All Features
 This method will fetch all features for a given user and return them as Dictionary<String, Feature>
 
 ```csharp
-...
-
-namespace Example {
-    public class AllFeaturesExample {
-        public async Task main() {
-            // using ensures REST Client resources are correctly disposed once no longer required.
-            using DVCCloudClient dvcClient = new DVCCloudClientBuilder()
-                .SetSDKKey("<DVC_SERVER_SDK_KEY>")
-                .Build();
-            var user = new User("user_id");
-
-            try {
-                Dictionary<string, Feature> result = await dvcClient.AllFeaturesAsync(user);
-                Debug.WriteLine(result);
-            } catch (Exception e) {
-                Debug.Print("Exception when calling dvcClient.AllFeaturesAsync: " + e.Message);
-            }
-        }
-    }
-}
+Dictionary<string, Feature> result = await client.AllFeaturesAsync(user);
 ```
 
 ## Track Event
 To POST custom event for a user, pass in the user and event object.
 
 ```csharp
-...
+DateTimeOffset now = DateTimeOffset.UtcNow;
+long unixTimeMilliseconds = now.ToUnixTimeMilliseconds();
 
-namespace Example {
-    public class TrackExample {
-        public void main() {
-            // Ensure REST Client resources are correctly disposed once no longer required
-            using DVCCloudClient dvcClient = new DVCCloudClientBuilder()
-                .SetSDKKey("<DVC_SERVER_SDK_KEY>")
-                .Build();
+var event = new Event("test event", "test target", unixTimeMilliseconds, 600, new Dictionary<string, object>(){{"key", "value"}});
 
-            DateTimeOffset now = DateTimeOffset.UtcNow;
-            long unixTimeMilliseconds = now.ToUnixTimeMilliseconds();
-            
-            var user = new Users("user_id");
-            var event = new Event("test event", "test target", unixTimeMilliseconds, 600, new Dictionary<string, object>(){{"key", "value"}});
-
-            try {
-                DVCResponse result = await dvcClient.TrackAsync(user, event);
-                Debug.WriteLine(result);
-            } catch (Exception e) {
-                Debug.Print("Exception when calling dvcClient.GetFeaturesAsync: " + e.Message);
-            }
-        }
-    }
-}
+DVCResponse result = await client.TrackAsync(user, event);
 ```
 
 ## EdgeDB

--- a/docs/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-usage.md
+++ b/docs/sdk/server-side-sdks/dotnet-cloud/dotnet-cloud-usage.md
@@ -25,7 +25,7 @@ value from the server unless an error occurs or the server has no response.
 In that case it will return a variable value with the value set to whatever was passed in as the `defaultValue` parameter.
 
 ```csharp
-Boolean result = await client.VariableValueAsync(user, "YOUR_KEY", true);
+bool result = await client.VariableValueAsync(user, "YOUR_KEY", true);
 ```
 
 The default value can be of type `String`, `Boolean`, `Number`, or `Object`.

--- a/docs/sdk/server-side-sdks/dotnet-local/dotnet-local-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/dotnet-local/dotnet-local-gettingstarted.md
@@ -24,10 +24,52 @@ namespace Example
     {
         static Main(string[] args)
         {
-            DVCLocalClientBuilder apiBuilder = new DVCLocalClientBuilder();
-            using DVCLocalClient api = apiBuilder.SetSDKKey("<DVC_SERVER_SDK_KEY>")
-                      .Build();
+            DVCLocalClientBuilder clientBuilder = new DVCLocalClientBuilder();
+            using DVCLocalClient client = clientBuilder.SetSDKKey("<DVC_SERVER_SDK_KEY>").Build();
         }
     }
 }
 ```
+
+## Intialization With Callback
+
+You can also setup a callback to be notified when the client is fully initialized and use `DVCLocalOptions` to further configure the client.
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DevCycle.SDK.Server.Local.Api;
+using DevCycle.SDK.Server.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Example {
+    public class Example {
+        private static DVCLocalClient client;
+        
+        static async Task Main(string[] args) {
+            DVCLocalClientBuilder clientBuilder = new DVCLocalClientBuilder();
+            client = clientBuilder.SetSDKKey("<DVC_SERVER_SDK_KEY>")
+                .SetOptions(new DVCLocalOptions(configPollingIntervalMs: 60000, eventFlushIntervalMs: 60000))
+                .SetInitializedSubscriber((o, e) => {
+                    if (e.Success) {
+                        ClientInitialized();
+                    } else {
+                        Console.WriteLine($"DevCycle Client did not initialize. Error: {e.Error}");
+                    }
+                })
+                .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))
+                .Build();
+
+            try {
+                await Task.Delay(5000);
+            } catch (TaskCanceledException) {
+                System.Environment.Exit(0);
+            }
+        }
+
+        private static void ClientInitialized() {
+            // Start using the client here
+        }
+    }
+}

--- a/docs/sdk/server-side-sdks/dotnet-local/dotnet-local-usage.md
+++ b/docs/sdk/server-side-sdks/dotnet-local/dotnet-local-usage.md
@@ -25,147 +25,24 @@ the user is not segmented into a feature using that variable, or the project con
 to be fetched from DevCycle's CDN.
 
 ```csharp
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using DevCycle.SDK.Server.Local.Api;
-using DevCycle.SDK.Server.Common;
-using Microsoft.Extensions.Logging;
-
-namespace Example {
-    public class VariableByKeyExample {
-        private static DVCLocalClient api;
-        
-        static async Task Main(string[] args) {
-            var user = new User("test");
-
-            DVCLocalClientBuilder apiBuilder = new DVCLocalClientBuilder();
-            api = apiBuilder.SetSDKKey("<DVC_SERVER_SDK_KEY>")
-                .SetOptions(new DVCOptions(1000, 5000))
-                .SetInitializedSubscriber((o, e) => {
-                    if (e.Success) {
-                        ClientInitialized(user);
-                    } else {
-                        Console.WriteLine($"Client did not initialize. Error: {e.Error}");
-                    }
-                })
-                .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))
-                .Build();
-
-            try {
-                await Task.Delay(5000);
-            } catch (TaskCanceledException) {
-                System.Environment.Exit(0);
-            }
-        }
-
-        private static void ClientInitialized(User user) {
-            bool boolVarValue = api.VariableValue(user, "my-bool-variable", true);
-            Console.WriteLine(boolVarValue);
-        }
-    }
-}
+bool boolVarValue = client.VariableValue(user, "my-bool-variable", true);
 ```
 
 ## Getting All Variables
 
 To get values from your Variables, the `Value` field inside the variable object can be accessed.
 
-This method will fetch all variables for a given user and returned as Dictionary&lt;String, Variable&gt;
+This method will fetch all variables for a given user and returned as Dictionary&lt;string, Variable&gt;
 
 ```csharp
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using DevCycle.SDK.Server.Local.Api;
-using DevCycle.SDK.Server.Common;
-using Microsoft.Extensions.Logging;
-
-namespace Example {
-    public class AllVariablesExample {
-        private static DVCLocalClient api;
-        
-        static async Task Main(string[] args) {
-            var user = new User("test");
-
-            DVCLocalClientBuilder apiBuilder = new DVCLocalClientBuilder();
-            api = apiBuilder.SetSDKKey("<DVC_SERVER_SDK_KEY>")
-                .SetOptions(new DVCOptions(1000, 5000))
-                .SetInitializedSubscriber((o, e) => {
-                    if (e.Success) {
-                        ClientInitialized(user);
-                    } else {
-                        Console.WriteLine($"Client did not initialize. Error: {e.Error}");
-                    }
-                })
-                .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))
-                .Build();
-
-            try {
-                await Task.Delay(5000);
-            } catch (TaskCanceledException) {
-                System.Environment.Exit(0);
-            }
-        }
-
-        private static void ClientInitialized(User user) {
-            Dictionary<string, Feature> result = api.AllVariables(user);
-
-            foreach (KeyValuePair<string, Variable> entry in result.GetAll()) {
-                Console.WriteLine(entry.Key + " : " + entry.Value);
-            }
-        }
-    }
-}
+Dictionary<string, Variable> variables = client.AllVariables(user);
 ```
 
 ## Getting All Features
-This method will fetch all features for a given user and return them as Dictionary<String, Feature>
+This method will fetch all features for a given user and return them as Dictionary<string, Feature>
 
 ```csharp
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using DevCycle.SDK.Server.Local.Api;
-using DevCycle.SDK.Server.Common;
-using Microsoft.Extensions.Logging;
-
-namespace Example {
-    public class AllFeaturesExample {
-        private static DVCLocalClient api;
-        
-        static async Task Main(string[] args) {
-            var user = new User("test");
-
-            DVCLocalClientBuilder apiBuilder = new DVCLocalClientBuilder();
-            api = apiBuilder.SetSDKKey("<DVC_SERVER_SDK_KEY>")
-                .SetOptions(new DVCOptions(1000, 5000))
-                .SetInitializedSubscriber((o, e) => {
-                    if (e.Success) {
-                        ClientInitialized(user);
-                    } else {
-                        Console.WriteLine($"Client did not initialize. Error: {e.Error}");
-                    }
-                })
-                .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))
-                .Build();
-
-            try {
-                await Task.Delay(5000);
-            } catch (TaskCanceledException) {
-                System.Environment.Exit(0);
-            }
-        }
-
-        private static void ClientInitialized(User user) {
-            Dictionary<string, Feature> result = api.AllFeatures(user);
-
-            foreach (KeyValuePair<string, Feature> entry in result) {
-                Console.WriteLine(entry.Key + " : " + entry.Value);
-            }
-        }
-    }
-}
+Dictionary<string, Feature> features = client.AllFeatures(user);
 ```
 
 ## Track Event
@@ -174,54 +51,12 @@ To POST custom event for a user, pass in the user and event object.
 Calling Track will queue the event, which will be sent in batches to the DevCycle servers.
 
 ```csharp
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using DevCycle.SDK.Server.Local.Api;
-using DevCycle.SDK.Server.Common;
-using Microsoft.Extensions.Logging;
+DateTimeOffset now = DateTimeOffset.UtcNow;
+long unixTimeMilliseconds = now.ToUnixTimeMilliseconds();
 
-namespace Example {
-    class Program {
-        private static DVCLocalClient api;
-        
-        static async Task Main(string[] args) {
-            var user = new User("test");
+var @event = new Event("test event", "test target", unixTimeMilliseconds, 600);
 
-            DVCLocalClientBuilder apiBuilder = new DVCLocalClientBuilder();
-            api = apiBuilder.SetSDKKey("<DVC_SERVER_SDK_KEY>")
-                .SetOptions(new DVCOptions(1000, 5000))
-                .SetInitializedSubscriber((o, e) => {
-                    if (e.Success) {
-                        ClientInitialized(user);
-                    } else {
-                        Console.WriteLine($"Client did not initialize. Error: {e.Error}");
-                    }
-                })
-                .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))
-                .Build();
-
-            try {
-                await Task.Delay(5000);
-            } catch (TaskCanceledException) {
-                System.Environment.Exit(0);
-            }
-        }
-
-        private static void ClientInitialized(User user) {
-            DateTimeOffset now = DateTimeOffset.UtcNow;
-            long unixTimeMilliseconds = now.ToUnixTimeMilliseconds();
-            
-            var @event = new Event("test event", "test target", unixTimeMilliseconds, 600);
-
-            try {
-                api.Track(user, @event);
-            } catch (Exception e) {
-                Console.WriteLine("Exception when calling DVCLocalClient.Track: " + e.Message);
-            }
-        }
-    }
-}
+client.Track(user, @event);
 ```
 
 ## Flush Events
@@ -229,54 +64,15 @@ namespace Example {
 Calling this method will immediately send all queued events to the DevCycle servers
 
 ```csharp
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using DevCycle.SDK.Server.Local.Api;
-using DevCycle.SDK.Server.Common;
-using Microsoft.Extensions.Logging;
-
-namespace Example {
-    class Program {
-        private static DVCLocalClient api;
-        
-        static async Task Main(string[] args) {
-            var user = new User("test");
-
-            DVCLocalClientBuilder apiBuilder = new DVCLocalClientBuilder();
-            api = apiBuilder.SetSDKKey("<DVC_SERVER_SDK_KEY>")
-                .SetOptions(new DVCOptions(1000, 5000))
-                .SetInitializedSubscriber((o, e) => {
-                    if (e.Success) {
-                        ClientInitialized(user);
-                    } else {
-                        Console.WriteLine($"Client did not initialize. Error: {e.Error}");
-                    }
-                })
-                .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))
-                .Build();
-
-            try {
-                await Task.Delay(5000);
-            } catch (TaskCanceledException) {
-                System.Environment.Exit(0);
-            }
-        }
-
-        private static void ClientInitialized(User user) {
-            api.FlushedEvents += (sender, args) => {
-                FlushedEvents(args);
-            };
-            api.FlushEvents();
-        }
-
-        private static void FlushedEvents(DVCEventArgs args) {
-            if (!args.Success) {
-                Console.WriteLine(args.Error);
-            }
-        }
+// Optional: setup a handler to react to the result of flushing events 
+client.FlushedEvents += (sender, args) => {
+    if (!args.Success) {
+        Console.WriteLine(args.Error);
     }
-}
+};
+
+// send events to DevCycle servers
+client.FlushEvents();
 ```
 
 ## Set Client Custom Data
@@ -284,47 +80,9 @@ namespace Example {
 To assist with segmentation and bucketing you can set a custom data dictionary that will be used for all variable and feature evaluations. User specific custom data will override client custom data.
 
 ```csharp
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using DevCycle.SDK.Server.Local.Api;
-using DevCycle.SDK.Server.Common;
-using Microsoft.Extensions.Logging;
+Dictionary<string, object> customData = new Dictionary<string, object>();
+customData.Add("some-key", "some-value");
 
-namespace Example {
-    public class ClientCustomDataExample {
-        private static DVCLocalClient api;
-        
-        static async Task Main(string[] args) {
-            var user = new User("test");
-
-            DVCLocalClientBuilder apiBuilder = new DVCLocalClientBuilder();
-            api = apiBuilder.SetSDKKey("<DVC_SERVER_SDK_KEY>")
-                .SetOptions(new DVCOptions(1000, 5000))
-                .SetInitializedSubscriber((o, e) => {
-                    if (e.Success) {
-                        ClientInitialized(user);
-                    } else {
-                        Console.WriteLine($"Client did not initialize. Error: {e.Error}");
-                    }
-                })
-                .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))
-                .Build();
-
-            try {
-                await Task.Delay(5000);
-            } catch (TaskCanceledException) {
-                System.Environment.Exit(0);
-            }
-        }
-
-        private static void ClientInitialized(User user) {
-            Dictionary<string, object> customData = new Dictionary<string, object>();
-            customData.Add("some-key", "some-value");
-            
-            // set the data into the DevCycle client
-            api.SetClientCustomData(customData);
-        }
-    }
-}
+// set the data into the DevCycle client
+client.SetClientCustomData(customData);
 ```

--- a/docs/sdk/server-side-sdks/dotnet-local/dotnet-local-usage.md
+++ b/docs/sdk/server-side-sdks/dotnet-local/dotnet-local-usage.md
@@ -258,3 +258,46 @@ namespace Example {
     }
 }
 ```
+
+## Set Client Custom Data
+
+To assist with segmentation and bucketing you can set a custom data dictionary that will be used for all variable and feature evaluations. User specific custom data will override client custom data.
+
+```csharp
+namespace Example {
+    public class ClientCustomDataExample {
+        private static DVCLocalClient api;
+        
+        static async Task Main(string[] args) {
+            var user = new User("test");
+
+            DVCLocalClientBuilder apiBuilder = new DVCLocalClientBuilder();
+            api = apiBuilder.SetSDKKey("<DVC_SERVER_SDK_KEY>")
+                .SetOptions(new DVCOptions(1000, 5000))
+                .SetInitializedSubscriber((o, e) => {
+                    if (e.Success) {
+                        ClientInitialized(user);
+                    } else {
+                        Console.WriteLine($"Client did not initialize. Error: {e.Error}");
+                    }
+                })
+                .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))
+                .Build();
+
+            try {
+                await Task.Delay(5000);
+            } catch (TaskCanceledException) {
+                System.Environment.Exit(0);
+            }
+        }
+
+        private static void ClientInitialized(User user) {
+            Dictionary<string, object> customData = new Dictionary<string, object>();
+            customData.Add("some-key", "some-value");
+            
+            // set the data into the DevCycle client
+            api.SetClientCustomData(customData);
+        }
+    }
+}
+```

--- a/docs/sdk/server-side-sdks/dotnet-local/dotnet-local-usage.md
+++ b/docs/sdk/server-side-sdks/dotnet-local/dotnet-local-usage.md
@@ -74,7 +74,12 @@ To get values from your Variables, the `Value` field inside the variable object 
 This method will fetch all variables for a given user and returned as Dictionary&lt;String, Variable&gt;
 
 ```csharp
-...
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DevCycle.SDK.Server.Local.Api;
+using DevCycle.SDK.Server.Common;
+using Microsoft.Extensions.Logging;
 
 namespace Example {
     public class AllVariablesExample {
@@ -118,7 +123,12 @@ namespace Example {
 This method will fetch all features for a given user and return them as Dictionary<String, Feature>
 
 ```csharp
-...
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DevCycle.SDK.Server.Local.Api;
+using DevCycle.SDK.Server.Common;
+using Microsoft.Extensions.Logging;
 
 namespace Example {
     public class AllFeaturesExample {
@@ -164,7 +174,12 @@ To POST custom event for a user, pass in the user and event object.
 Calling Track will queue the event, which will be sent in batches to the DevCycle servers.
 
 ```csharp
-...
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DevCycle.SDK.Server.Local.Api;
+using DevCycle.SDK.Server.Common;
+using Microsoft.Extensions.Logging;
 
 namespace Example {
     class Program {
@@ -214,7 +229,12 @@ namespace Example {
 Calling this method will immediately send all queued events to the DevCycle servers
 
 ```csharp
-...
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DevCycle.SDK.Server.Local.Api;
+using DevCycle.SDK.Server.Common;
+using Microsoft.Extensions.Logging;
 
 namespace Example {
     class Program {
@@ -264,6 +284,13 @@ namespace Example {
 To assist with segmentation and bucketing you can set a custom data dictionary that will be used for all variable and feature evaluations. User specific custom data will override client custom data.
 
 ```csharp
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DevCycle.SDK.Server.Local.Api;
+using DevCycle.SDK.Server.Common;
+using Microsoft.Extensions.Logging;
+
 namespace Example {
     public class ClientCustomDataExample {
         private static DVCLocalClient api;

--- a/docs/sdk/server-side-sdks/go/go-usage.md
+++ b/docs/sdk/server-side-sdks/go/go-usage.md
@@ -66,8 +66,6 @@ This method will fetch all features for a given user and return them in a map of
 features, err := client.AllFeatures(user)
 ```
 
-Local Bucketing will return an error if there was a problem either
-
 ## Getting All Variables
 
 To get values from your Variables, the `value` field inside the variable object can be accessed.
@@ -85,6 +83,21 @@ You can close the DevCycle client to stop the SDK from polling for configs and f
 ```go
 err := client.Close()
 ```
+
+## Set Client Custom Data
+
+To assist with segmentation and bucketing you can set a custom data map that will be used for all variable and feature evaluations. User specific custom data will override this client custom data.
+
+```go
+err = client.SetClientCustomData(map[string]interface{}{
+    "some-key": "some-value",
+})
+```
+
+:::caution
+Client Custom Data is only available for the Local Bucketing SDK
+:::
+
 
 ## EdgeDB
 

--- a/docs/sdk/server-side-sdks/java-cloud/java-cloud-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/java-cloud/java-cloud-gettingstarted.md
@@ -17,10 +17,10 @@ import com.devcycle.sdk.server.cloud.api.DVCCloudClient;
 
 public class MyClass {
     
-    private DVCCloudClient dvcCloudClient;
+    private DVCCloudClient client;
     
     public MyClass() {
-        dvcCloudClient = new DVCCloudClient("<DVC_SERVER_SDK_KEY>");
+        client = new DVCCloudClient("<DVC_SERVER_SDK_KEY>");
     }
 }
 ```
@@ -37,14 +37,14 @@ import com.devcycle.sdk.server.cloud.model.DVCCloudOptions;
 
 public class MyClass {
     
-    private DVCCloudClient dvcCloudClient;
+    private DVCCloudClient client;
 
-    private DVCCloudOptions dvcCloudOptions = DVCLocalOptions.builder()
-        .enableEdgeDB(false)
-        .build();
-    
     public MyClass() {
-        dvcCloudClient = new DVCCloudClient("<DVC_SERVER_SDK_KEY>", dvcCloudOptions);
+        DVCCloudOptions options = DVCLocalOptions.builder()
+            .enableEdgeDB(false)
+            .build();
+        
+        client = new DVCCloudClient("<DVC_SERVER_SDK_KEY>", options);
     }
 }
 ```

--- a/docs/sdk/server-side-sdks/java-local/java-local-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/java-local/java-local-gettingstarted.md
@@ -17,10 +17,10 @@ import com.devcycle.sdk.server.local.api.DVCLocalClient;
 
 public class MyClass {
     
-    private DVCLocalClient dvcLocalClient;
+    private DVCLocalClient client;
     
     public MyClass() {
-        dvcLocalClient = new DVCLocalClient("<DVC_SERVER_SDK_KEY>");
+        client = new DVCLocalClient("<DVC_SERVER_SDK_KEY>");
     }
 }
 ```
@@ -45,9 +45,10 @@ import com.devcycle.sdk.server.local.model.DVCLocalOptions;
 
 public class MyClass {
     
-    private DVCLocalClient dvcLocalClient;
-
-    private DVCLocalOptions dvcLocalOptions = DVCLocalOptions.builder()
+    private DVCLocalClient client;
+    
+    public MyClass() {
+        DVCLocalOptions options = DVCLocalOptions.builder()
         .configPollingIntervalMs(60000)
         .configRequestTimeoutMs(30000)
         .eventFlushIntervalMS(10000)
@@ -60,8 +61,7 @@ public class MyClass {
         .disableCustomEventLogging(false)
         .build();
     
-    public MyClass() {
-        dvcLocalClient = new DVCLocalClient("<DVC_SERVER_SDK_KEY>", dvcLocalOptions);
+        client = new DVCLocalClient("<DVC_SERVER_SDK_KEY>", options);
     }
 }
 ```

--- a/docs/sdk/server-side-sdks/java-local/java-local-usage.md
+++ b/docs/sdk/server-side-sdks/java-local/java-local-usage.md
@@ -144,6 +144,30 @@ public class MyClass {
 }
 ```
 
+## Set Client Custom Data
+
+To assist with segmentation and bucketing you can set a custom data map that will be used for all variable and feature evaluations. User specific custom data will override client custom data.
+
+```java
+
+public class MyClass {
+    private DVCLocalClient dvcLocalClient;
+
+    public MyClass() {
+        dvcLocalClient = new DVCLocalClient("<DVC_SERVER_SDK_KEY>");
+    }
+
+    public void setCustomData() {
+        // create a map of custom data
+        Map<String,Object> customData = new HashMap();
+        customData.put("some-key", "some-value");
+
+        // set the map into the DevCycle client
+        dvcLocalClient.setClientCustomData(customData);
+    }
+}
+```
+
 ## EdgeDB
 
 :::caution

--- a/docs/sdk/server-side-sdks/python/python-usage.md
+++ b/docs/sdk/server-side-sdks/python/python-usage.md
@@ -97,19 +97,22 @@ except Exception as e:
     print(f"Exception when calling DevCycleLocalClient->track: {e}")        
 ```
 
-## Set Global Custom Data
+## Set Client Custom Data
 
-To assist with segmentation and bucketing you can set a global custom data dictionary that will be used for all variable and feature evaluations. User specific custom data will override global custom data.
+To assist with segmentation and bucketing you can set a custom data dictionary that will be used for all variable and feature evaluations. User specific custom data will override this client custom data.
 
 ```python
-# Set global custom data
-client.set_client_custom_data({
-    "some-key": "some-value"
-})
+try:
+    # Set client custom data
+    client.set_client_custom_data({
+        "some-key": "some-value"
+    })
+except Exception as e:
+    print(f"Exception when calling DevCycleLocalClient->set_client_custom_data: {e}")
 ```
 
 :::caution
-Global Custom Data is only available for the Local Bucketing SDK
+Client Custom Data is only available for the Local Bucketing SDK
 :::
 
 ## EdgeDB

--- a/docs/sdk/server-side-sdks/ruby/ruby-usage.md
+++ b/docs/sdk/server-side-sdks/ruby/ruby-usage.md
@@ -49,7 +49,7 @@ You can fetch all segmented features for a user:
 
 ```ruby
 begin
-  #Get all features for user data
+  # Get all features for user data
   result = dvc_client.all_features(user_data)
   p result
 rescue
@@ -63,7 +63,7 @@ To grab all the segmented variables for a user:
 
 ```ruby
 begin
-  #Get all variables for user data
+  # Get all variables for user data
   result = dvc_client.all_variables(user_data)
   p result
 rescue
@@ -102,6 +102,24 @@ To provide a custom logger, override the `logger` property of the SDK configurat
 ```ruby
 options = DevCycle::DVCOptions.new(logger: @yourCustomLogger)
 ```
+
+## Set Client Custom Data
+
+To assist with segmentation and bucketing you can set a custom data hash that will be used for all variable and feature evaluations. User specific custom data will override this client custom data.
+
+```ruby
+begin
+  # Set client custom data
+  custom_data = {"some-key" : "some-value"}
+  dvc_client.set_client_custom_data(custom_data)
+rescue => e
+  puts "Exception when calling DVCClient->set_client_custom_data: #{e}"
+end
+```
+
+:::caution
+Client Custom Data is only available for the Local Bucketing SDK
+:::
 
 ## EdgeDB
 


### PR DESCRIPTION
added entries and code samples for all the server SDKs that currently support setting custom client data

updated the Java and DotNet usage examples so they are code snippets instead of big boiler plate code samples