### PR TITLE
Update react-native-gettingstarted.md

### DIFF
--- a/docs/sdk/client-side-sdks/react-native/react-native-gettingstarted.md
+++ b/docs/sdk/client-side-sdks/react-native/react-native-gettingstarted.md
@@ -78,5 +78,3 @@ The SDK exposes various initialization options which can be set by passing a `De
 | apiProxyURL | string | Allows the SDK to communicate with a proxy of DevCycle bucketing API / client SDK API. |
 | configCacheTTL | number | The maximum allowed age of a cached config in milliseconds, defaults to 7 days |
 | disableConfigCache | boolean | Disable the use of cached configs |
-| disableRealtimeUpdates | boolean | Disable Realtime Updates |
-


### PR DESCRIPTION
Removes reference to Realtime Updates which is not available in React Native SDK at the current point in time.

Thanks to @leslie-lau for catching this in June and apologies it has taken so long to address.