### PR TITLE
remove references to web elements from js example label

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -1,6 +1,6 @@
 ---
 title: DevCycle Example Apps
-sidebar_class_name: hidden    
+sidebar_class_name: hidden
 ---
 import CustomDocCardList from '@site/src/components/CustomDocCardList'
 
@@ -12,7 +12,7 @@ Welcome to the Example Apps page, which showcases example applications using the
   {
     type: 'link',
     href: 'https://github.com/DevCycleHQ/js-sdks/tree/main/examples/js/web-elements-app',
-    label: 'JavaScript (Web Elements)',
+    label: 'JavaScript',
     description: 'hidden',
     iconSet: 'fab',
 icon:'js'
@@ -61,7 +61,7 @@ icon:'toggle-on'
 
 ## Server Side
 
-### Local Bucketing 
+### Local Bucketing
 ([See here for more explanation](/sdk/#difference-between-local-and-cloud-bucketing))
 <CustomDocCardList columnWidth={6} items={[
   {
@@ -122,7 +122,7 @@ icon:'golang'
   },
 ]} />
 
-### Cloud Bucketing 
+### Cloud Bucketing
 ([See here for more explanation](/sdk/#difference-between-local-and-cloud-bucketing))
 
 <CustomDocCardList columnWidth={6} items={[


### PR DESCRIPTION
- just say Javascript as the name of the javascript example app