### PR TITLE
Update serverless-cloud-functions.md

### DIFF
--- a/docs/best-practices/serverless/serverless-cloud-functions.md
+++ b/docs/best-practices/serverless/serverless-cloud-functions.md
@@ -66,7 +66,6 @@ To set the feature flags, make sure you have a DevCycle account [https://devcycl
     
 3. Add the environment variable `SERVER_KEY` under “Runtime environment variables” ([Related Google Doc](https://cloud.google.com/functions/docs/configuring/env-var) 
 For getting the server-side SDK key from DevCycle, you can read this section ([https://docs.devcycle.com/essentials/keys](/essentials/keys))
-    
     ![Screen Shot 2022-09-13 at 11.51.57 AM.png](/Screen_Shot_2022-09-13_at_11.51.57_AM.png)
     
 4. Click “Next” and enter the ([contents of the `index.js` from the example repo](https://github.com/DevCycleHQ/google-cloud-functions-example/blob/main/index.js)) into the Console


### PR DESCRIPTION
removed space causing screenshot breakage
![screenshot-error](https://github.com/DevCycleHQ/devcycle-docs/assets/19987735/e9f33b9b-723e-45d4-8984-1b86f5e510ed)
