### PR TITLE
feat: Add gitlab code usage docs

### DIFF
--- a/docs/integrations/gitlab/_category_.yml
+++ b/docs/integrations/gitlab/_category_.yml
@@ -1,0 +1,3 @@
+label: 'GitLab'
+position: 3
+collapsed: true

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -80,13 +80,21 @@ icon:'file-import'
     iconSet: 'fab',
     icon:'bitbucket'
   },
-    {
+  {
     type: 'link',
     href: '/integrations/bitbucket/pr-insights-action',
     description: 'Display added/removed flags on each Pull Request.',
     label: 'Bitbucket: Flag Change Insights',
     iconSet: 'fab',
     icon:'bitbucket'
+  },
+  {
+    type: 'link',
+    href: '/integrations/gitlab/feature-usage-action',
+     description: 'Display code snippets for each variable used in a project.',
+    label: 'GitLab: Flag Code Usages',
+    iconSet: 'fab',
+    icon:'gitlab'
   },
   {
     type: 'link',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -172,7 +172,20 @@ const config = {
           content: '# Bitbucket: Feature Flag Change Insights on Pull Request \n' + content
         })
       },
-    ]
+    ],
+    [
+      'docusaurus-plugin-remote-content',
+      {
+        name: 'gitlab.feature-usage-action',
+        sourceBaseUrl: 'https://gitlab.com/devcycle/devcycle-usages-ci-cd/-/raw/main/',
+        outDir: 'docs/integrations/gitlab/feature-usage-action',
+        documents: ['README.md'],
+        performCleanup: true,
+        modifyContent: (filename, content) => ({
+          content: '# GitLab: Feature Flag Code Usages \n' + content
+        })
+      }
+    ],
   ],
 
   presets: [


### PR DESCRIPTION
Add docs for GitLab code usages, sourced from the repo readme.

Note: this shouldn't be merged until the feature is ready for release