### PR TITLE
chore: add GitLab merge request insights docs

### DIFF
--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -96,6 +96,14 @@ icon:'file-import'
     iconSet: 'fab',
     icon:'gitlab'
   },
+    {
+    type: 'link',
+    href: '/integrations/gitlab/pr-insights-action',
+     description: 'Display added/removed flags on each Merge Request.',
+    label: 'GitLab: Flag Change Insights',
+    iconSet: 'fab',
+    icon:'gitlab'
+  },
   {
     type: 'link',
     href: '/integrations/jira',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -186,6 +186,19 @@ const config = {
         })
       }
     ],
+    [
+      'docusaurus-plugin-remote-content',
+      {
+        name: 'gitlab.pr-insights-action',
+        sourceBaseUrl: 'https://gitlab.com/devcycle/devcycle-pr-insights-ci-cd/-/raw/main/',
+        outDir: 'docs/integrations/gitlab/pr-insights-action',
+        documents: ['README.md'],
+        performCleanup: true,
+        modifyContent: (filename, content) => ({
+          content: '# GitLab: Feature Flag Change Insights on Merge Request \n' + content
+        })
+      }
+    ]
   ],
 
   presets: [


### PR DESCRIPTION
Add docs for GitLab merge request insights.

**Note: this shouldn't be merged until the feature is ready for release**