### PR TITLE
Remove the table for DotNet

### DIFF
--- a/docs/sdk/server-side-sdks/dotnet/dotnet-install.md
+++ b/docs/sdk/server-side-sdks/dotnet/dotnet-install.md
@@ -10,7 +10,17 @@ sidebar_custom_props: {icon: screwdriver-wrench}
 [![Nuget Local](https://badgen.net/nuget/v/DevCycle.SDK.Server.Cloud)](https://www.nuget.org/packages/DevCycle.SDK.Server.Local/)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/dotnet-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/dotnet-server-sdk)
 
-| Local                                                                                                                                                               | Cloud                                                                                                                                                                                                                     |
-|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Download the SDK from Nuget - https://nuget.info/packages/DevCycle.SDK.Server.Local/ <br/> and use the namespaces: <br/> ```using DevCycle.SDK.Server.Local.Api;``` | Download the SDK from Nuget - https://www.nuget.org/packages/DevCycle.SDK.Server.Cloud/ <br/> and use the namespaces: <br/> ```using DevCycle.SDK.Server.Cloud.Api;```<br/>``` using DevCycle.SDK.Server.Common.Model;``` |
+## Local Bucketing                                                                                                                                                               
+Download the SDK from Nuget - https://nuget.info/packages/DevCycle.SDK.Server.Local/ 
 
+and use the namespaces: 
+
+`using DevCycle.SDK.Server.Local.Api;` 
+
+## Cloud Bucketing
+Download the SDK from Nuget - https://www.nuget.org/packages/DevCycle.SDK.Server.Cloud/ 
+
+and use the namespaces: 
+
+`using DevCycle.SDK.Server.Cloud.Api;`
+`using DevCycle.SDK.Server.Common.Model;`


### PR DESCRIPTION
Make the dotnet table disappear. 
It messes up the docs embedding on the dashboard.
