### PR TITLE
Swap out links to polished example apps for js, react, vue, node

### DIFF
--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -11,7 +11,7 @@ Welcome to the Example Apps page, which showcases example applications using the
 <CustomDocCardList  columnWidth={6}  items={[
   {
     type: 'link',
-    href: 'https://github.com/DevCycleHQ/js-sdks/tree/main/examples/js/web-elements-app',
+    href: 'https://github.com/DevCycleHQ-Labs/example-javascript',
     label: 'JavaScript',
     description: 'hidden',
     iconSet: 'fab',
@@ -19,11 +19,27 @@ icon:'js'
   },
   {
     type: 'link',
+    href: 'https://github.com/DevCycleHQ-Labs/example-react-with-provider',
+    label: 'React Provider',
+    description: 'hidden',
+    iconSet: 'fab',
+    icon:'react'
+  },
+  {
+    type: 'link',
     href: 'https://github.com/DevCycleHQ/js-sdks/tree/main/examples/nextjs',
     label: 'React (NextJS)',
     description: 'hidden',
-        iconSet: 'fab',
-icon:'react'
+    iconSet: 'fab',
+    icon:'react'
+  },
+  {
+    type: 'link',
+    href: 'https://github.com/DevCycleHQ-Labs/example-vue3',
+    label: 'Vue JS',
+    description: 'hidden',
+    iconSet: 'fab',
+    icon:'vuejs'
   },
    {
     type: 'link',
@@ -66,7 +82,7 @@ icon:'toggle-on'
 <CustomDocCardList columnWidth={6} items={[
   {
     type: 'link',
-    href: 'https://github.com/DevCycleHQ/js-sdks/tree/main/examples/nodejs-local',
+    href: 'https://github.com/DevCycleHQ-Labs/example-nodejs',
     label: 'NodeJS',
     description: 'hidden',
     iconSet: 'fab',


### PR DESCRIPTION
<img width="1249" alt="image" src="https://github.com/DevCycleHQ/devcycle-docs/assets/25067948/88304aa4-df9e-49e0-a63b-579fcf73372a">

swaps out the new links and adds a separate card for the regular react example vs the nextjs example