### PR TITLE
docs updates for defaulting and allVariables

### DIFF
--- a/docs/extras/advanced-variables/variable-defaults.md
+++ b/docs/extras/advanced-variables/variable-defaults.md
@@ -56,3 +56,6 @@ what users should receive unless otherwise specified by a Feature. We believe th
 where applications are more likely to behave as expected in the very unlikely chance that DevCycle _is_ unreachable,
 and also make it easier for developers to reason about the behaviour of an application without having to refer to the DevCycle
 dashboard to determine the "baseline" value.
+
+It is always still possible to define your own "fallback" value in the DevCycle platform by adding a final Targeting Rule to a Feature that targets
+"All Users" and serves your intended "fallback" variation.

--- a/docs/extras/advanced-variables/variable-defaults.md
+++ b/docs/extras/advanced-variables/variable-defaults.md
@@ -42,7 +42,7 @@ the DevCycle configuration will include the Variable values they should be serve
 However, if a user does not qualify for a Feature, the Variables it contains will not be given any values in the configuration.
 Instead, the SDK will continue to serve the default value as defined in code. 
 
-The same is true if a Feature is turned "off" in an environment. The DevCycle platform treats that Feature as essentially
+The same is true if a Feature has targeting turned "off" in an environment. The DevCycle platform treats that Feature as essentially
 having no effect on the configuration.
 
 This behaviour differs from other Feature Flagging platforms, where you often need to define a "fallback" value that 

--- a/docs/extras/advanced-variables/variable-defaults.md
+++ b/docs/extras/advanced-variables/variable-defaults.md
@@ -18,7 +18,7 @@ as defined in code.
 SDKs will attempt to retrieve the configuration until an error is received or a timeout is reached. In these cases,
 the configuration will not be obtained and default values will be used for the duration of the SDK instance's lifetime.
 
-## Type Mismatches
+### Type Mismatches
 In many SDKs, the type of the default value (Boolean, String etc.) determines the "expected" type of the Variable.
 On the DevCycle platform, a Variable is configured to have a specific type, and a Feature controls the values of that
 given type to assign to the Variable.
@@ -31,10 +31,10 @@ For example, if a Variable is being evaluated in code and the Boolean value `fal
 the SDK will understand that that Variable should always be a Boolean. If the DevCycle configuration serves a String 
 value instead, the SDK will ignore it and use the default value of `false` instead.
 
-## Variable Does Not Exist
+### Variable Does Not Exist
 In cases where the Variable does not exist in the DevCycle platform, the SDK will use the default value provided in code.
 
-## User Does Not Qualify for Targeting, or Feature is Turned Off
+### User Does Not Qualify for Targeting, or Feature is Turned Off
 In DevCycle, the values of Variables are controlled by Features. Those Features contain Targeting Rules that determine who
 is eligible to receive the Feature, and what Variation they should be served. In cases where a user qualifies for a Feature,
 the DevCycle configuration will include the Variable values they should be served.

--- a/docs/extras/advanced-variables/variable-defaults.md
+++ b/docs/extras/advanced-variables/variable-defaults.md
@@ -1,0 +1,58 @@
+---
+title: Variable Defaults
+sidebar_position: 2
+---
+
+Variable defaults are the values you provide in code which tell DevCycle SDKs what value to assign to variable in
+cases where a different value is not available. 
+
+It's worth understanding which scenarios a variable will be defaulted in, as this can differ from other Feature Flagging
+platforms.
+
+## When is the default value used?
+
+### Configuration Not Available
+If the SDK has not yet received a configuration from DevCycle, it will return the default value for a variable 
+as defined in code. 
+
+SDKs will attempt to retrieve the configuration until an error is received or a timeout is reached. In these cases,
+the configuration will not be obtained and default values will be used for the duration of the SDK instance's lifetime.
+
+## Type Mismatches
+In many SDKs, the type of the default value (Boolean, String etc.) determines the "expected" type of the Variable.
+On the DevCycle platform, a Variable is configured to have a specific type, and a Feature controls the values of that
+given type to assign to the Variable.
+
+But what if the type as defined in DevCycle does not agree with what your code expects? In that scenario, DevCycle
+will defer to the code's expected type by preserving the default value and not attempt to override it with the value
+from the configuration. This behaviour ensures that the SDK will not cause runtime errors due to type mismatches.
+
+For example, if a Variable is being evaluated in code and the Boolean value `false` is provided as a default value,
+the SDK will understand that that Variable should always be a Boolean. If the DevCycle configuration serves a String 
+value instead, the SDK will ignore it and use the default value of `false` instead.
+
+## Variable Does Not Exist
+In cases where the Variable does not exist in the DevCycle platform, the SDK will use the default value provided in code.
+
+## User Does Not Qualify for Targeting, or Feature is Turned Off
+In DevCycle, the values of Variables are controlled by Features. Those Features contain Targeting Rules that determine who
+is eligible to receive the Feature, and what Variation they should be served. In cases where a user qualifies for a Feature,
+the DevCycle configuration will include the Variable values they should be served.
+
+However, if a user does not qualify for a Feature, the Variables it contains will not be given any values in the configuration.
+Instead, the SDK will continue to serve the default value as defined in code. 
+
+The same is true if a Feature is turned "off" in an environment. The DevCycle platform treats that Feature as essentially
+having no effect on the configuration.
+
+This behaviour differs from other Feature Flagging platforms, where you often need to define a "fallback" value that 
+the platform should serve in cases where no other value has been specified. 
+
+We took a different approach, because we believe that the default value in your code is more important than that.
+It should always represent a valid value for your application, and usually represents the state the application should
+be in if no other rules have been applied to modify its behaviour. By making the default value more than just a "once in a million"
+value used when DevCycle is unreachable, we want to encourage developers to treat it as the "baseline" value representing
+what users should receive unless otherwise specified by a Feature. We believe this will lead to an approach to feature flagging
+where applications are more likely to behave as expected in the very unlikely chance that DevCycle _is_ unreachable,
+and also make it easier for developers to reason about the behaviour of an application without having to refer to the DevCycle
+dashboard to determine the "baseline" value.

--- a/docs/extras/advanced-variables/variable-defaults.md
+++ b/docs/extras/advanced-variables/variable-defaults.md
@@ -3,16 +3,16 @@ title: Variable Defaults
 sidebar_position: 2
 ---
 
-Variable defaults are the values you provide in code which tell DevCycle SDKs what value to assign to variable in
+Variable defaults are the values you provide in code which tell DevCycle SDKs what value to assign to a Variable in
 cases where a different value is not available. 
 
-It's worth understanding which scenarios a variable will be defaulted in, as this can differ from other Feature Flagging
+It's worth understanding which scenarios a Variable will be defaulted in, as this can differ from other Feature Flagging
 platforms.
 
 ## When is the default value used?
 
 ### Configuration Not Available
-If the SDK has not yet received a configuration from DevCycle, it will return the default value for a variable 
+If the SDK has not yet received a configuration from DevCycle, it will return the default value for a Variable 
 as defined in code. 
 
 SDKs will attempt to retrieve the configuration until an error is received or a timeout is reached. In these cases,

--- a/docs/sdk/client-side-sdks/android/android-usage.md
+++ b/docs/sdk/client-side-sdks/android/android-usage.md
@@ -87,6 +87,15 @@ Map<String, BaseConfigVariable> variables = devcycleClient.allVariables();
 
 If the SDK has not finished initializing, these methods will return an empty Map.
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Using Variable Values](#using-variable-values)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 ## Get All Features
 
 To grab all the Features returned in the config:

--- a/docs/sdk/client-side-sdks/android/android-usage.md
+++ b/docs/sdk/client-side-sdks/android/android-usage.md
@@ -87,7 +87,7 @@ Map<String, BaseConfigVariable> variables = devcycleClient.allVariables();
 
 If the SDK has not finished initializing, these methods will return an empty Map.
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Using Variable Values](#using-variable-values)

--- a/docs/sdk/client-side-sdks/flutter/flutter-usage.md
+++ b/docs/sdk/client-side-sdks/flutter/flutter-usage.md
@@ -58,6 +58,15 @@ Map<String, DVCVariable> variables = await _devcycleClient.allVariables();
 
 If the SDK has not finished initializing, these methods will return an empty object.
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Using Variable Values](#using-variable-values)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 ## Get All Features
 
 To get all the Features returned in the config:

--- a/docs/sdk/client-side-sdks/flutter/flutter-usage.md
+++ b/docs/sdk/client-side-sdks/flutter/flutter-usage.md
@@ -58,7 +58,7 @@ Map<String, DVCVariable> variables = await _devcycleClient.allVariables();
 
 If the SDK has not finished initializing, these methods will return an empty object.
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Using Variable Values](#using-variable-values)

--- a/docs/sdk/client-side-sdks/ios/ios-usage.md
+++ b/docs/sdk/client-side-sdks/ios/ios-usage.md
@@ -110,6 +110,15 @@ NSDictionary *allVariables = [self.devcycleClient allVariables];
 
 If the SDK has not finished initializing, these methods will return an empty object.
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Using Variable Values](#using-variable-values)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 ## Identifying User
 
 To identify a different user, or the same user passed into the initialize method with more attributes,

--- a/docs/sdk/client-side-sdks/ios/ios-usage.md
+++ b/docs/sdk/client-side-sdks/ios/ios-usage.md
@@ -110,7 +110,7 @@ NSDictionary *allVariables = [self.devcycleClient allVariables];
 
 If the SDK has not finished initializing, these methods will return an empty object.
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Using Variable Values](#using-variable-values)

--- a/docs/sdk/client-side-sdks/javascript/javascript-usage.md
+++ b/docs/sdk/client-side-sdks/javascript/javascript-usage.md
@@ -150,7 +150,7 @@ If the SDK has not finished initializing, these methods will return an empty obj
 
 See [getVariables](https://docs.devcycle.com/bucketing-api/#operation/getVariables) in the Bucketing API for detailed response formats.
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Using Variable Values](#using-variable-values)

--- a/docs/sdk/client-side-sdks/javascript/javascript-usage.md
+++ b/docs/sdk/client-side-sdks/javascript/javascript-usage.md
@@ -150,6 +150,15 @@ If the SDK has not finished initializing, these methods will return an empty obj
 
 See [getVariables](https://docs.devcycle.com/bucketing-api/#operation/getVariables) in the Bucketing API for detailed response formats.
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Using Variable Values](#using-variable-values)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 ## Tracking Events
 
 To track events, pass in an object with at least a `type` key:

--- a/docs/sdk/client-side-sdks/react-native/react-native-usage.md
+++ b/docs/sdk/client-side-sdks/react-native/react-native-usage.md
@@ -129,7 +129,7 @@ The client object can be obtained from the [useDevCycleClient](#useDevCycleClien
 
 If the SDK has not finished initializing, these methods will return an empty object.
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Getting a Variable](#getting-a-variable)

--- a/docs/sdk/client-side-sdks/react-native/react-native-usage.md
+++ b/docs/sdk/client-side-sdks/react-native/react-native-usage.md
@@ -129,6 +129,15 @@ The client object can be obtained from the [useDevCycleClient](#useDevCycleClien
 
 If the SDK has not finished initializing, these methods will return an empty object.
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Getting a Variable](#getting-a-variable)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 ## Track Events
 
 Events can be tracked by calling the `track` method provided by the client object, which you can access with the

--- a/docs/sdk/client-side-sdks/react/react-usage.md
+++ b/docs/sdk/client-side-sdks/react/react-usage.md
@@ -136,6 +136,15 @@ If the SDK has not finished initializing, these methods will return an empty obj
 
 See [getVariables](https://docs.devcycle.com/bucketing-api/#operation/getVariables) and [getFeatures](https://docs.devcycle.com/bucketing-api/#operation/getFeatures) on the Bucketing API for the response formats.
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Getting a Variable](#getting-a-variable)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 :::note
 
 The DevCycle React SDK is built upon the JavaScript SDK. For further details, view [the JavaScript SDK documentation](/sdk/client-side-sdks/javascript)

--- a/docs/sdk/client-side-sdks/react/react-usage.md
+++ b/docs/sdk/client-side-sdks/react/react-usage.md
@@ -136,7 +136,7 @@ If the SDK has not finished initializing, these methods will return an empty obj
 
 See [getVariables](https://docs.devcycle.com/bucketing-api/#operation/getVariables) and [getFeatures](https://docs.devcycle.com/bucketing-api/#operation/getFeatures) on the Bucketing API for the response formats.
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Getting a Variable](#getting-a-variable)

--- a/docs/sdk/features.md
+++ b/docs/sdk/features.md
@@ -7,9 +7,9 @@ DevCycle strives to ensure that all our APIs and SDKs have identical functionali
 
 **Universal**
 * [Initialization](#initialization)
+* [Evaluating Features & Using Variables](#evaluating-features--using-variables)
 * [Getting All Features](#getting-all-features)
 * [Getting All Variables](#getting-all-variables)
-* [Evaluating Features & Using Variables](#evaluating-features-&-using-variables)
 * [Identifying Users / Setting Properties](#Identifying-a-User-or-Setting-Properties)
 * [Tracking Events](#tracking-custom-events)
 
@@ -33,6 +33,30 @@ Additionally, if the SDK is interacted with before any initialization (such as a
 
 If a variable is first read from the cache and has a listener for [realtime updates](#realtime-updates), if a new value is retrieved after initialization, the `onUpdate` function will be triggered.
 
+## Evaluating Features & Using Variables
+
+This section explains how to use retrieve the Variables of a Feature as well as use their values. For information on setting up a Feature for use, read [Variables and Variations](/essentials/variables) and [Targeting Users](/essentials/targeting)
+
+Every SDK provides a method to retrieve a variable's value. It expects to receive the unique key of the variable, and a default value to serve in case no other value is available.
+
+A typical variable method would look something like this:
+```typescript
+const myVariableValue = devcycleClient.variableValue('my-variable-key', 'default-value')
+```
+
+Each call to this method is tracked as an "evaluation" event. These events will be shown in the DevCycle dashboard and are used to power the analytics graphs
+that allow you to see the effects of your Variables being used.
+
+The default value will be returned in the following scenarios:
+- The SDK has not yet finished initializing and obtaining a configuration from DevCycle
+- There was an error reaching the DevCycle servers and the configuration could not be obtained
+- The variable does not exist in DevCycle
+- The default value's type does not align with the type of the variable being served from DevCycle. For example, a Boolean default value
+    will be used if the DevCycle configuration is trying to set this variable to a String value. This preserves type safety and prevents the remote
+    configuration from breaking your application at runtime.
+- The SDK has finished initializing, but the user has not been targeted for a Feature that controls this Variable
+
+For more information on how the default value is used, see [Variable Defaults](/extras/advanced-variables/variable-defaults).
 
 
 ## Getting All Features
@@ -57,10 +81,7 @@ The response is the following general format, with slight changes depending on t
   },...
 ```
 
-Only Features that the User has been successfully targeted for. [Targeting rules](/essentials/targeting) must be **enabled** for that environment.  
-
-Features that within the Project that have rules disabled OR the user is not Targeted for will not appear in the response of this function. 
-
+Only Features that the User has satisfied [targeting rules](/essentials/targeting) for will be returned by this function. The feature must also be **enabled** for that environment.
 
 ## Getting all Variables
 
@@ -84,17 +105,16 @@ The response is the following general format, with slight changes depending on t
   },
 ```
 
-Only Variables in Features that the user has been successfully targeted for will be part of the response to this SDK. [Targeting rules](/essentials/targeting) must be **enabled** for the environment this SDK is being called on.  
+Only Variables in Features that the user has satisfied [targeting rules](/essentials/targeting) for will be part of the response in this method. The Feature must also be **enabled** for the environment this SDK is being called on.
 
-Features within the Project that have rules disabled OR the user is not Targeted for will not have their variables appear in the response of this function. 
+:::info
 
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour. 
+For that purpose, we strongly recommend using the individual variable access method described in [Evaluating Features & Using Variables](#evaluating-features--using-variables)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
 
-
-## Evaluating Features & Using Variables
-
-This article explains how to use retrieve the Variables of a Feature as well as use their values. For information on setting up a Feature for use, read [Variables and Variations](/essentials/variables) and [Targeting Users](/essentials/targeting)
-
-If there is an error reaching DevCycle, if the requested variable does not exist, OR if the user has not been Targeted for the requested feature, the SDKs will return the default value provided to the SDK in code. In that case, the variable returned from the function will not contain the `_id` or `type` fields.
+:::
 
 ## Identifying a User or Setting Properties
 

--- a/docs/sdk/features.md
+++ b/docs/sdk/features.md
@@ -37,9 +37,9 @@ If a variable is first read from the cache and has a listener for [realtime upda
 
 This section explains how to use retrieve the Variables of a Feature as well as use their values. For information on setting up a Feature for use, read [Variables and Variations](/essentials/variables) and [Targeting Users](/essentials/targeting)
 
-Every SDK provides a method to retrieve a variable's value. It expects to receive the unique key of the variable, and a default value to serve in case no other value is available.
+Every SDK provides a method to retrieve a Variable's value. It expects to receive the unique key of the Variable, and a default value to serve in case no other value is available.
 
-A typical variable method would look something like this:
+A typical Variable method would look something like this:
 ```typescript
 const myVariableValue = devcycleClient.variableValue('my-variable-key', 'default-value')
 ```

--- a/docs/sdk/features.md
+++ b/docs/sdk/features.md
@@ -71,14 +71,15 @@ The response is the following general format, with slight changes depending on t
     "_id": "123456",
     "key": "your-cool-feature",
     "type": "release",
-    "_variation":"333345"
+    "_variation": "333345"
   },
   "another-feature": {
     "_id": "123456",
     "key": "another-feature",
     "type": "ops",
-    "_variation":"444123"
-  },...
+    "_variation": "444123"
+  }
+}
 ```
 
 Only Features that the User has satisfied [targeting rules](/essentials/targeting) for will be returned by this function. The feature must also be **enabled** for that environment.
@@ -102,12 +103,13 @@ The response is the following general format, with slight changes depending on t
     "key": "some-string-variable",
     "type": "String",
     "value": "this is a string variable value"
-  },
+  }
+}
 ```
 
 Only Variables in Features that the user has satisfied [targeting rules](/essentials/targeting) for will be part of the response in this method. The Feature must also be **enabled** for the environment this SDK is being called on.
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour. 
 For that purpose, we strongly recommend using the individual variable access method described in [Evaluating Features & Using Variables](#evaluating-features--using-variables)
@@ -131,7 +133,7 @@ The user data object that you should use across SDKs should look something like 
     "user_id": "user1@devcycle.com",
     "name": "user 1 name",
     "customData": {
-        "customKey": "customValue"?
+        "customKey": "customValue"
     },
     "privateCustomData": {
         "privateKey": "privateValue"

--- a/docs/sdk/server-side-sdks/dotnet/dotnet-usage.md
+++ b/docs/sdk/server-side-sdks/dotnet/dotnet-usage.md
@@ -45,6 +45,15 @@ This method will fetch all variables for a given user and return as `Dictionary<
 Dictionary<string, ReadOnlyVariable<object>> result = await client.AllVariables(user);
 ```
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 ## Getting All Features
 
 This method will fetch all features for a given user and return them as `Dictionary<String, Feature>`

--- a/docs/sdk/server-side-sdks/dotnet/dotnet-usage.md
+++ b/docs/sdk/server-side-sdks/dotnet/dotnet-usage.md
@@ -45,7 +45,7 @@ This method will fetch all variables for a given user and return as `Dictionary<
 Dictionary<string, ReadOnlyVariable<object>> result = await client.AllVariables(user);
 ```
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)

--- a/docs/sdk/server-side-sdks/go/go-usage.md
+++ b/docs/sdk/server-side-sdks/go/go-usage.md
@@ -76,7 +76,7 @@ This method will fetch all variables for a given user and return them in a map o
 variables, err := devcycleClient.AllVariables(user)
 ```
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)

--- a/docs/sdk/server-side-sdks/go/go-usage.md
+++ b/docs/sdk/server-side-sdks/go/go-usage.md
@@ -76,6 +76,15 @@ This method will fetch all variables for a given user and return them in a map o
 variables, err := devcycleClient.AllVariables(user)
 ```
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 ## Close
 
 You can close the DevCycle client to stop the SDK from polling for configs and flushing events on an interval. Any pending events will be immediately flushed. This method is only usable in local bucketing mode.

--- a/docs/sdk/server-side-sdks/java-cloud/java-cloud-usage.md
+++ b/docs/sdk/server-side-sdks/java-cloud/java-cloud-usage.md
@@ -51,7 +51,7 @@ To get values from your Variables, the `value` field inside the variable object 
 ```java
 Map<String, Variable> variables = client.allVariables(user);
 ```
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)

--- a/docs/sdk/server-side-sdks/java-cloud/java-cloud-usage.md
+++ b/docs/sdk/server-side-sdks/java-cloud/java-cloud-usage.md
@@ -51,7 +51,14 @@ To get values from your Variables, the `value` field inside the variable object 
 ```java
 Map<String, Variable> variables = client.allVariables(user);
 ```
+:::info
 
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
 ## Getting All Features
 
 This method will fetch all features for a given user and return them as `Map<String, Feature>`

--- a/docs/sdk/server-side-sdks/java-local/java-local-usage.md
+++ b/docs/sdk/server-side-sdks/java-local/java-local-usage.md
@@ -52,7 +52,14 @@ To get values from your Variables, the `value` field inside the variable object 
 ```java
 Map<String, Variable> variables = client.allVariables(user);
 ```
+:::info
 
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
 ## Getting All Features
 
 This method will fetch all features for a given user and return them as Map&lt;String, Feature&gt;.

--- a/docs/sdk/server-side-sdks/java-local/java-local-usage.md
+++ b/docs/sdk/server-side-sdks/java-local/java-local-usage.md
@@ -52,7 +52,7 @@ To get values from your Variables, the `value` field inside the variable object 
 ```java
 Map<String, Variable> variables = client.allVariables(user);
 ```
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)

--- a/docs/sdk/server-side-sdks/node/node-usage.md
+++ b/docs/sdk/server-side-sdks/node/node-usage.md
@@ -57,6 +57,15 @@ const variables = devcycleClient.allVariables(user)
 
 See [getVariables](/bucketing-api/#operation/getVariables) on the Bucketing API for the variable response format.
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 ## Getting All Features
 
 You can fetch all segmented features for a user:

--- a/docs/sdk/server-side-sdks/node/node-usage.md
+++ b/docs/sdk/server-side-sdks/node/node-usage.md
@@ -57,7 +57,7 @@ const variables = devcycleClient.allVariables(user)
 
 See [getVariables](/bucketing-api/#operation/getVariables) on the Bucketing API for the variable response format.
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)

--- a/docs/sdk/server-side-sdks/php/php-usage.md
+++ b/docs/sdk/server-side-sdks/php/php-usage.md
@@ -56,7 +56,7 @@ try {
 
 See [getVariables](/bucketing-api/#operation/getVariables) on the Bucketing API for the variable response format.
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)

--- a/docs/sdk/server-side-sdks/php/php-usage.md
+++ b/docs/sdk/server-side-sdks/php/php-usage.md
@@ -56,6 +56,15 @@ try {
 
 See [getVariables](/bucketing-api/#operation/getVariables) on the Bucketing API for the variable response format.
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 ## Getting all Features
 
 ```php

--- a/docs/sdk/server-side-sdks/python/python-usage.md
+++ b/docs/sdk/server-side-sdks/python/python-usage.md
@@ -63,7 +63,7 @@ except Exception as e:
 
 See [getVariables](/bucketing-api/#operation/getVariables) on the Bucketing API for the variable response format.
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)

--- a/docs/sdk/server-side-sdks/python/python-usage.md
+++ b/docs/sdk/server-side-sdks/python/python-usage.md
@@ -63,6 +63,15 @@ except Exception as e:
 
 See [getVariables](/bucketing-api/#operation/getVariables) on the Bucketing API for the variable response format.
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 ## Getting All Features
 
 Use the `all_features()` method to retrieve a dictionary with all the segmented features for the user.

--- a/docs/sdk/server-side-sdks/ruby/ruby-usage.md
+++ b/docs/sdk/server-side-sdks/ruby/ruby-usage.md
@@ -71,6 +71,15 @@ rescue
 end
 ```
 
+:::info
+
+This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
+Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
+of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
+
+:::
+
 ## Track Events
 
 Track a custom event for a user, pass in the user and event object.

--- a/docs/sdk/server-side-sdks/ruby/ruby-usage.md
+++ b/docs/sdk/server-side-sdks/ruby/ruby-usage.md
@@ -71,7 +71,7 @@ rescue
 end
 ```
 
-:::info
+:::caution
 
 This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)


### PR DESCRIPTION
- add doc explaining variable defaulting behaviour
- add warning to allVariables method in various places
- fix missing content and structure of main "SDK features" landing page
- re-order sections of SDK Features to mention how to get a variable value first, and finish that section as well as add additional details about variable defaulting