### PR TITLE
add home link to navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -373,6 +373,13 @@ const config = {
         srcDark: 'devcycle-docs-white.svg',
       },
       items: [
+          {
+              type: 'doc',
+              docId: 'index',
+              position: 'left',
+              collapse: 'false',
+              label: 'Home',
+          },
         {
           type: 'doc',
           docId: 'sdk/index',


### PR DESCRIPTION
It's kind of unintuitive that the only way to return to "home" is by knowing you can click the logo