### PR TITLE
clean up sdk section

### DIFF
--- a/docs/extras/custom-domains/_category_.yml
+++ b/docs/extras/custom-domains/_category_.yml
@@ -1,0 +1,2 @@
+label: 'Custom Domains'
+position: 11

--- a/docs/extras/custom-domains/custom-domains.md
+++ b/docs/extras/custom-domains/custom-domains.md
@@ -1,0 +1,75 @@
+---
+title: Custom Domains
+sidebar_position: 1
+---
+
+# Custom Domains
+
+When using client-side SDKs, particularly web client SDKs, there is the potential for ad blockers
+and browser privacy features to block requests and third-party cookies. Custom Domains with DevCycle ensures
+all cookies and requests used are first-party and will not be blocked by ensuring requests are sent through your
+recognized domain. A DNS CNAME needs to be created to leverage this feature.
+
+:::info
+
+**Setting Up Custom Domains:**
+
+Custom Domains is an enterprise feature and requires manual setup on both your end as well as DevCycle's. If you are interested in getting set up these docs will guide you through the steps, but please reach out to support@devcycle.com for assistance.
+
+:::
+
+#### Custom Certificate
+
+If you'd like to have a custom certificate for the endpoint to be used, please contact your account representative. This requires additional steps that change the flow of this process.
+
+#### Setup Steps
+
+1. **Identifying a Hostname**
+
+- The first step involves **identifying** a hostname to use as the CNAME for DevCycle's endpoint. Provide this to DevCycle upon requesting to enable this feature. The hostname should look something like this `https://api-alias.your-domain.com`.
+    - If there is more than one service in use, each one will need a unique CNAME. This is also true for using DevCycle on multiple domains. Each domain needs its own CNAME.
+
+2. **DNS Validation**
+   Once the setup is complete, two DNS records will be provided by DevCycle and you will need to add those records to your DNS provider (TXT validation records).
+
+- The first DNS record will be a TXT verification record to ensure that you own the domain that you are asking DevCycle to use as a custom hostname.
+- The second DNS record will be a TXT verification record to ensure that you have permission to create an SSL certificate for said domain. This record will conflict with any existing A/AAAA or CNAME records on the hostname and require them to be removed before adding the verification record.
+
+Once these records have been added, please let DevCycle know.
+
+3. **Additional Setup Step**
+   Once validation is complete and DevCycle has confirmed the records are set properly, there may be an extra step involved here with DevCycle depending on your SDK configuration. DevCycle will let you know if this is needed.
+
+4. **Creating a CNAME**
+   Once all steps are complete, DevCycle will send the details for the DNS CNAME. Once added, the service will be immediately available at the given hostname.
+
+#### SDK Implementation
+
+Once you have completed the above setup to create a CNAME, proceed in modifying your existing SDK initialization to include the `apiProxyURL` initialization option.
+
+**JS SDK Initialization Update**
+
+Add the `apiProxyURL` option and your CNAME domains as per the [JS SDK Initialization Options](https://docs.devcycle.com/sdk/client-side-sdks/javascript/javascript-gettingstarted#initialization-options).
+
+```javascript
+const devcycleClient = initializeDevCycle('<DVC_CLIENT_SDK_KEY>', user, {
+  apiProxyURL: 'https://api-alias.your-domain.com',
+})
+```
+
+**iOS SDK Initialization Update**
+
+Add the `apiProxyURL` option and your CNAME domains as per the [iOS SDK DevCycle Options Builder](https://docs.devcycle.com/sdk/client-side-sdks/ios/ios-gettingstarted#devcycleoptions-builder).
+
+```swift
+let options = DevCycleOptions.builder().apiProxyURL("https://api-alias.your-domain.com").build()
+let client =  try? DevCycleClient.builder()
+            .sdkKey("<DEVCYCLE_SDK_KEY>")
+            .user(user!)
+            .options(options)
+            .build(onInitialized: nil)
+```
+
+After completing the steps above, users should be able to freely maneuver around AdBlockers and prevent them from blocking requests to our API servers and our SDK.
+
+If you have any questions regarding this process, please reach out to our [support](mailto:support@devcycle.com) team.

--- a/docs/sdk/features.md
+++ b/docs/sdk/features.md
@@ -298,7 +298,7 @@ Custom Domains is an enterprise feature and requires manual setup on both your e
 
 :::
 
-For instructions on setting up a custom domain, see [Custom Domains](/extras/custom-domains/custom-domains).
+For instructions on setting up a custom domain, see [Custom Domains](/extras/custom-domains).
 
 ## Realtime Updates
 

--- a/docs/sdk/features.md
+++ b/docs/sdk/features.md
@@ -20,11 +20,8 @@ functionality that DevCycle supports across the SDKs.
 
 - [Custom Domains](#custom-domains)
 - [Realtime Updates](#realtime-updates)
-- [Reset User](#reset-user)
 
 ## Initialization
-
-This section will cover how to initialize each SDK as well as explain their starting options.
 
 ### Client-Side SDKs
 
@@ -90,14 +87,15 @@ A typical Variable method would look something like this:
 
 ```typescript
 const myVariableValue = devcycleClient.variableValue(
+  // Variable "key"
   'my-variable-key',
+  // Default value to use if DevCycle has no other value
   'default-value',
 )
 ```
 
 Each call to this method is tracked as an "evaluation" event. These events will be shown in the DevCycle dashboard and 
-are used to power the analytics graphs
-that allow you to see the effects of your Variables being used.
+are used to power the analytics graphs that allow you to see the effects of your Variables being used.
 
 The default value will be returned in the following scenarios:
 
@@ -113,9 +111,7 @@ For more information on how the default value is used, see [Variable Defaults](/
 
 ## Getting All Features
 
-The "Get All Features" function in an SDK will return a map of all of the features that the user is currently in 
-based on the information the SDK or API has received.
-
+The "Get All Features" function in an SDK will return a map of all the features that the user is currently receiving.
 The response is the following general format, with slight changes depending on the specifics of the SDK:
 
 ```json
@@ -135,11 +131,12 @@ The response is the following general format, with slight changes depending on t
 }
 ```
 
-Only Features that the User has satisfied [targeting rules](/essentials/targeting) for will be returned by this function. The feature must also be **enabled** for that environment.
+Only Features that the User has satisfied [targeting rules](/essentials/targeting) for will be returned by this function. 
+The feature must also be **enabled** for that environment.
 
 ## Getting all Variables
 
-The "Get All Variables" function in an SDK will return a map of all of the Variables that the user has received from the DevCycle server based on the information the SDK or API has received.
+The "Get All Variables" function in an SDK will return a map of all the Variables that the user is receiving.
 
 The response is the following general format, with slight changes depending on the specifics of the SDK:
 
@@ -160,7 +157,8 @@ The response is the following general format, with slight changes depending on t
 }
 ```
 
-Only Variables in Features that the user has satisfied [targeting rules](/essentials/targeting) for will be part of the response in this method. The Feature must also be **enabled** for the environment this SDK is being called on.
+Only Variables in Features that the user has satisfied [targeting rules](/essentials/targeting) for will be part of the response in this method. 
+The Feature must also be **enabled** for the environment this SDK is being called on.
 
 :::caution
 
@@ -173,12 +171,16 @@ of other DevCycle features such as [Code Usage detection](/integrations/github/f
 
 ## Identifying a User or Setting Properties
 
-The Client-Side SDKs and Server-Side SDKs function slightly differently. 
-This documentation will cover all of the information needed to set user data and custom properties on both types of SDKs.
+All SDKs have the concept of a user "identity" to be used for evaluating feature targeting rules. The Features
+that are served to a user will be a function of the targeting rules and the user data you provide to the SDK.
 
-The documentation will also cover the differences between regular data and private data.
+:::tip
 
-Regardless of the SDK type or the type of custom data you are looking to use, the general format of user data remains largely the same.
+While we refer to these identities as "users", the data passed here can represent anything you want to target against.
+In these cases, you can use any string that makes sense as an identifier as the "user_id". The id simply needs to be
+consistent to ensure consistent random distributions and rollouts.
+
+:::
 
 The user data object that you should use across SDKs should look something like this:
 
@@ -195,59 +197,98 @@ The user data object that you should use across SDKs should look something like 
 }
 ```
 
+The identification of users functions differently on Client SDKs vs. Server SDKs
+
+### Client SDK Identification
+
+Client SDKs can be initialized with a user object if the user data is known at that time. All client SDKs accept
+a "user" argument in their initialization function. By providing the user here, the SDK's initial configuration request
+will be made with that data and the correct Variable values will be available once the SDK initializes. For that reason,
+providing user data during initialization is recommended where possible.
+
+Identifying a user can also be accomplished later by calling the `identifyUser` function and providing your
+user data object. When this method is called, the SDK will retrieve a new configuration from the DevCycle servers
+corresponding to that user. A typical call to this method looks like
+
+```typescript
+const user = {
+  user_id: 'myUser'
+}
+
+await devCycleClient.identifyUser(user)
+```
+
+The `identifyUser` method always includes a way to wait for the operation to finish. When finished, the SDK will have
+the correct configuration for the given user and all Variable evaluations from that point onward will be based on the
+new user's data. This method is useful when user data can not be known at initialization time, or when the user's 
+identity must be changed during the application's lifecycle.
+
 #### Anonymous Users
 
 :::info
 
-If a user id is not supplied, client-side SDKs will automatically generate a user id and assign it to the current user. This id will be cached and used between app opens / website visits until a user id is supplied or [reset](#reset-user) is called. This will ensure you will not experience a rise in MAUs if the main experience of your application is in a logged-out or anonymous state.
+If a user id is not supplied, client-side SDKs will automatically generate a user id and assign it to the current user. 
+This id will be cached and used between app sessions / website visits until a user id is supplied or [reset](#reset-user) is 
+called. This will ensure you will not experience a rise in MAUs if the main experience of your application is in a logged-out or anonymous state.
 
 :::
 
-:::tip
+#### Resetting a User
+Client SDKs also contain a method for "resetting" a user's identity. This can be used in cases like "logging out", where there is no longer
+any identifiable information to pass to the SDK. In those cases, "reset" will clear all stored data and generate a new "anonymous" user ID
+to represent the user.
 
-In some cases, you may be releasing a feature broadly and not to users, specifically. In these cases, you can use any string as the "user_id". A user is not expressly required, just an identifier.
+#### Custom Data and Private Custom Data
 
-:::
+User data can also contain "custom data", which is a key-value map of any arbitrary data you want to use for targeting.
+The provided data can be used in Targeting Rules by creating Custom Properties in the DevCycle dashboard. Learn more
+about [Custom Property Targeting](/extras/advanced-targeting/custom-properties)
 
-#### Custom Data vs. Private Custom Data
+When setting custom properties you have a choice between keeping that data completely private or allowing 
+for the data to be logged back to DevCycle's events database. Both options allow for the same targeting capabilities, 
+but you should use Private Custom Data if you are looking to avoid having user data saved to any external system.
 
-When setting custom properties you have a choice between keeping that data completely private or allowing for the data to be logged back to DevCycle's events database. Both options allow for the same targeting capabilities, but you should use Private Custom Data if you are looking to avoid having user data saved to any external system.
+With Private Custom Data, data is used solely for targeting decisions within DevCycle's Edge Workers. 
+It is then discarded and no record is saved anywhere.
 
-With Private Custom Data, data is just used solely for evaluating decisions with DevCycle's Edge Workers, it is then discarded and no record is saved anywhere.
+With regular Custom Data, the data used for evaluation purposes is logged back to DevCycle's events database where 
+it can be used for debugging purposes or providing guidance on evaluation reasons.
 
-With regular Custom Data, the data used for evaluation purposes is logged back to DevCycle's events database where it can be used for debugging purposes or providing guidance on evaluation reasons.
+#### Server-Side SDK Identification
 
-:::info
+Unlike the Client-Side SDKs, Server-Side SDKs work in a multi-user context. 
+Because of this, a single Identify function does not make sense. 
+Instead, you must provide the user data to each function call when evaluating variables. For example:
 
-**EdgeDB Usage:** Given Private Custom Data is not written to any DevCycle systems it cannot be used with EdgeDB, as EdgeDB by its nature saves Custom Data to an Edge Database for flag evaluations.
+```typescript
+const user = {
+    user_id: 'myUser'
+}
 
-:::
+const myVariableValue = devcycleClient.variableValue(
+  // User data
+  user,
+  // Variable "key"
+  'my-variable-key',
+  // Default value to use if DevCycle has no other value
+  'default-value'
+)
+```
 
-#### Client-Side SDK Usage
-
-The Identify function is what is used on the Client-Side SDKs to set User IDs as well as custom properties. These SDKs are built to work in a single-user context on the device. The DevCycle Client-Side SDKs contain local storage of the current user's information for re-use with each function call. Using the Identify function will add to this storage.
-
-Any call to the Identify function will return the list of relevant Features and Variables for the User.
-
-If your application handles multiple users at once, simply call the Identify function with their new user object and DevCycle will retrieve that user's set of Features and Variables.
-
-To reset a user completely, please view [Resetting a User](#reset-user).
-
-#### Server-Side SDK Usage
-
-Unlike the Client-Side SDKs, Server-Side SDKs work in a multi-user context. Because of this, a single Identify function does not make sense. Instead, you must create a User object that is passed into each function call with the relevant user data given the current application context.
-
-As well, unlike the Client-Side SDKs, because Server-Side SDKs poll for project configuration updates, updating the User object that you have set will not explicitly grab new feature configurations. The User object once set can be used to get feature, variation and variable information for a given user or entity.
+In [Local Bucketing](#local-bucketing) mode (the default), these calls will quickly compute the variable value locally using the currently
+stored DevCycle configuration, and no network calls will be made.
 
 ## Tracking Custom Events
 
-This article serves to explain how to use the SDKs to send up custom events to DevCycle.
-
-The Track function in the DevCycle SDKs allows you to send up custom events which can later be used for your own data analysis on enabled Features, and metrics on A/B tests and experiments within the DevCycle dashboard.
+The Track function in the DevCycle SDKs allows you to send custom events which can later be used for your own data analysis on enabled Features,
+and metrics on A/B tests and experiments within the DevCycle dashboard.
 
 ## Custom Domains
 
-When using client-side SDKs, particularly web client SDKs there is the potential for Ad Blockers and browser privacy features to block requests and third-party cookies. Custom Domains with DevCycle ensures all cookies and requests used are first-party and will not be blocked by ensuring requests are sent through your recognized domain. A DNS CNAME needs to be created to leverage this feature.
+When using client-side SDKs, particularly web client SDKs there is the potential for Ad Blockers 
+and browser privacy features to block requests and third-party cookies. Custom Domains with DevCycle ensures
+all cookies and requests used are first-party and will not be blocked by ensuring requests are sent through your
+recognized domain. A DNS CNAME needs to be created to leverage this feature.
 
 :::info
 
@@ -257,76 +298,13 @@ Custom Domains is an enterprise feature and requires manual setup on both your e
 
 :::
 
-#### Custom Certificate
-
-If you'd like to have a custom certificate for the endpoint to be used, please contact your account representative. This requires additional steps that change the flow of this process.
-
-##### Setup Steps
-
-1. **Identifying a Hostname**
-
-- The first step involves **identifying** a hostname to use as the CNAME for DevCycle's endpoint. Provide this to DevCycle upon requesting to enable this feature. The hostname should look something like this `https://api-alias.your-domain.com`.
-  - If there is more than one service in use, each one will need a unique CNAME. This is also true for using DevCycle on multiple domains. Each domain needs its own CNAME.
-
-2. **DNS Validation**
-   Once the setup is complete, two DNS records will be provided by DevCycle and you will need to add those records to your DNS provider (TXT validation records).
-
-- The first DNS record will be a TXT verification record to ensure that you own the domain that you are asking DevCycle to use as a custom hostname.
-- The second DNS record will be a TXT verification record to ensure that you have permission to create an SSL certificate for said domain. This record will conflict with any existing A/AAAA or CNAME records on the hostname and require them to be removed before adding the verification record.
-
-Once these records have been added, please let DevCycle know.
-
-3. **Additional Setup Step**
-   Once validation is complete and DevCycle has confirmed the records are set properly, there may be an extra step involved here with DevCycle depending on your SDK configuration. DevCycle will let you know if this is needed.
-
-4. **Creating a CNAME**
-   Once all steps are complete, DevCycle will send the details for the DNS CNAME. Once added, the service will be immediately available at the given hostname.
-
-#### SDK Implementation
-
-Once you have completed the above setup to create a CNAME, proceed in modifying your existing SDK initialization to include the `apiProxyURL` initialization option.
-
-**JS SDK Initialization Update**
-
-Add the `apiProxyURL` option and your CNAME domains as per the [JS SDK Initialization Options](https://docs.devcycle.com/sdk/client-side-sdks/javascript/javascript-gettingstarted#initialization-options).
-
-```javascript
-const devcycleClient = initializeDevCycle('<DVC_CLIENT_SDK_KEY>', user, {
-  apiProxyURL: 'https://api-alias.your-domain.com',
-})
-```
-
-**iOS SDK Initialization Update**
-
-Add the `apiProxyURL` option and your CNAME domains as per the [iOS SDK DevCycle Options Builder](https://docs.devcycle.com/sdk/client-side-sdks/ios/ios-gettingstarted#devcycleoptions-builder).
-
-```swift
-let options = DevCycleOptions.builder().apiProxyURL("https://api-alias.your-domain.com").build()
-let client =  try? DevCycleClient.builder()
-            .sdkKey("<DEVCYCLE_SDK_KEY>")
-            .user(user!)
-            .options(options)
-            .build(onInitialized: nil)
-```
-
-After completing the steps above, users should be able to freely maneuver around AdBlockers and prevent them from blocking requests to our API servers and our SDK.
-
-If you have any questions regarding this process, please reach out to our [support](mailto:support@devcycle.com) team.
-
-## Reset User
-
-This article serves to explain how to use the SDKs to quickly reset the user context on Client-Side SDKs.
-
-#### Identifying a User or Setting Properties
-
-Currently, the Identify function is only available on Client-Side SDKs. These SDKs are built to work in a single-user context on the device. The DevCycle Client-Side SDKs contain local storage of the current user's information for re-use with each function call. Using the Identify function will add to this storage. Using this function will completely reset the current user in context.
+For instructions on setting up a custom domain, see [Custom Domains](/extras/custom-domains/custom-domains).
 
 ## Realtime Updates
 
-This article serves to explain how the SDKs handle realtime updates triggered by changes to your features from the DevCycle dashboard.
-
-DevCycle leverages Server-Sent Events (SSE) to notify the SDKs that their config has changed and that they should fetch a new config. When a change
-to a feature (targeting rules, variable values, etc.) has been saved, our servers send an SSE to anyone subscribed to that project and trigger the SDK to request a new config from DevCycle.
+DevCycle SDKs are capable of being notified in real time that new configuration changes have been made in the DevCycle platform.
+DevCycle leverages Server-Sent Events (SSE) to notify the SDKs that a feature (targeting rules, variable values, etc.)
+has been saved and that they should fetch the new configuration.
 
 #### Client-Side SDK
 
@@ -348,3 +326,24 @@ If the user loses focus on the webpage for longer then the `inactivityDelay` (th
 ##### **iOS SDK**, **Android SDK** & **Flutter SDK**
 
 If the user backgrounds the application for some period of time, the SDK will disconnect from the SSE provider and will reconnect again when the user brings the application to the foreground. When the application is brought to the foreground the SDK will request a new configuration to receive any updates it may have missed while the realtime connection was closed.
+
+## Local and Cloud Bucketing
+
+Server SDKs have two modes, "Local Bucketing" and "Cloud Bucketing":
+
+### Local Bucketing
+
+Local Bucketing does all targeting decisions locally inside the server running the SDK. The DevCycle
+configuration is downloaded upon initialization of the SDK, and all future SDK calls will determine flag values
+based on this data and the provided user data. This approach will guarantee instantaneous, synchronous results
+from the SDK.
+
+### Cloud Bucketing
+
+The SDK determines flag values by making an API call for each decision, using workers at the edge which are available
+globally. Every function within the SDK will reach out to these edge workers and respond with
+extremely low latency.
+
+Cloud bucketing is required to use specific features such as (EdgeDB)[/extras/edgedb] and
+(Feature Opt-In)[/extras/advanced-targeting/feature-opt-in]. If you aren't using these features, then Local Bucketing
+is the recommended mode.

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -7,8 +7,8 @@ displayed_sidebar: sdks
 
 import CustomDocCardList from '@site/src/components/CustomDocCardList'
 
-DevCycle has both client-side and server-side SDKs. This page serves to describe the differences between these SDK types
-and how to handle them. Implementation and usage change depending on which type of SDK is being used.
+DevCycle has both client-side and server-side SDKs. This page describes the differences between these SDK types.
+Implementation and usage change depending on which type of SDK is being used.
 
 :::tip
 Explore our [SDK Features and Functionality](/sdk/features) to discover how to implement your solutions using the DevCycle SDKs.
@@ -18,10 +18,9 @@ Explore our [SDK Features and Functionality](/sdk/features) to discover how to i
 
 ### Client Side SDKs
 
-DevCycle client-side SDKs are meant for single-user contexts. This means that the SDKs have a persistent data store for
-the user while the SDK is being used. Evaluation of Features happens directly on the client's device. These SDKs also
-include the Mobile SDKs. For more information on the difference between mobile and standard client-side SDK keys,
-read [API and SDK keys](/essentials/keys).
+DevCycle client-side SDKs are meant for single-user contexts, such as web browsers and mobile apps. These SDKs retrieve
+their configuration for the current user when they are initialized and any time the user is re-identified. They also
+receive updates in real time when configuration is changed in the DevCycle platform.
 
 The current Client-Side SDKs are:
 
@@ -82,9 +81,8 @@ The current Client-Side SDKs are:
 
 ### Server-Side SDKs
 
-Server-side SDKs are used in multi-user contexts where each call to the SDK will likely be for a different user. Each
-call to a server SDK function requires the user's ID and any other targeting information to be passed in on every
-function call. These SDKs are made for infrastructure, backend, and other such services.
+Server-side SDKs are used in multi-user contexts such as backend services, where each call to the SDK will likely be
+for a different user. The user's ID and any other targeting information must be passed in on every SDK function call.
 
 The current Server-Side SDKs are:
 
@@ -95,83 +93,49 @@ The current Server-Side SDKs are:
       type: 'link',
       href: '/sdk/server-side-sdks/node',
       label: 'NodeJS SDK',
-      description: 'Local and Cloud Bucketing',
       icon: 'simple-icons:nodedotjs',
     },
     {
       type: 'link',
       href: '/sdk/server-side-sdks/nestjs',
       label: 'NestJS SDK',
-      description: 'Local Bucketing',
       icon: 'simple-icons:nestjs',
     },
     {
       type: 'link',
       href: '/sdk/server-side-sdks/go',
       label: 'Go SDK',
-      description: 'Local and Cloud Bucketing',
       icon: 'simple-icons:go',
     },
     {
       type: 'link',
       href: '/sdk/server-side-sdks/php',
       label: 'PHP SDK',
-      description: 'Cloud Bucketing',
       icon: 'simple-icons:php',
     },
     {
       type: 'link',
       href: '/sdk/server-side-sdks/python',
       label: 'Python SDK',
-      description: 'Local and Cloud Bucketing',
       icon: 'simple-icons:python',
     },
     {
       type: 'link',
       href: '/sdk/server-side-sdks/ruby',
       label: 'Ruby SDK',
-      description: 'Local and Cloud Bucketing',
       icon: 'simple-icons:ruby',
     },
     {
       type: 'link',
       href: '/sdk/server-side-sdks/java',
       label: 'Java SDK',
-      description: 'Local and Cloud Bucketing',
       icon: 'la:java',
     },
     {
       type: 'link',
       href: '/sdk/server-side-sdks/dotnet',
       label: '.NET SDK',
-      description: 'Local and Cloud Bucketing',
       icon: 'simple-icons:dotnet',
     },
   ]}
 />
-
-## Difference between Local and Cloud Bucketing
-
-<!--tabs-->
-
-### Local Bucketing SDKs
-
-Local Bucketing does all calculations locally using extremely performant WebAssembly code. The project's
-environment configuration is downloaded upon initialization of the SDK, and all future SDK calls will calculate values
-locally within the SDK. This approach will guarantee responses from the SDK in 1-10ms. The configuration will be updated
-at a configurable polling interval.
-
-### Cloud Bucketing SDKs
-
-The logic which determines what a user gets is calculated in the cloud, using workers at the edge which are available
-globally. Every function within the SDK will reach out to these edge workers and respond with the response with
-extremely low latency. The Cloud Bucketing SDKs will cause a large number of outbound requests as each SDK call will
-reach out to the DevCycle edge servers. However, the cloud bucketing SDKs are useful in cases in which a much older
-version of the given language is being used, as Local Bucketing generally only supports newer versions of languages.
-
-## SDK Proxy
-
-Designed for cases where the language design doesn't support a long lived background process to contain the Local
-Bucketing engine and configuration data; the Local Bucketing Proxy was made to emulate the Cloud Bucketing API's
-and allow and SDK to have greater performance; close to that of the local bucketing SDKs. For more information see
-[SDK Proxy](./sdk-proxy/index.md).


### PR DESCRIPTION
- remove explanations of local vs cloud bucketing from main SDK page and move to SDK Features
- remove explanation of SDK Proxy
- create new page for custom domains
- remove explanation of custom domains from SDK Features
- move and write up explanation of resetting user in SDK features
- restructure Identification section in SDK Features
- remove redundant wording in various places
- remove "Local" and "Cloud" bucketing description labels from SDK tiles on SDKs page