### PR TITLE
remove create react app instructions and move react 17 warning

### DIFF
--- a/docs/sdk/client-side-sdks/react/react-install.md
+++ b/docs/sdk/client-side-sdks/react/react-install.md
@@ -13,18 +13,6 @@ sidebar_custom_props: { icon: material-symbols:install-desktop }
 
 This SDK is compatible with React versions 16.8.0 and above.
 
-:::info
-
-For React 17.x, there is an underlying issue for how the React Runtime is resolved.
-
-The interim fix, is to add an alias resolution to your build configuration for `'react/jsx-runtime': require.resolve('react/jsx-runtime')`.
-
-For more information, please review these Github Issues [React Issue](https://github.com/facebook/react/issues/20235), [Create React App Issue](https://github.com/facebook/create-react-app/issues/11769) & related PR [React Runtime PR](https://github.com/facebook/create-react-app/pull/11797).
-
-For additional help, please contact DevCycle support at [support@devcycle.com](mailto:support@devcycle.com).
-
-:::
-
 ## Installation
 
 To install the SDK, run the following command:
@@ -41,55 +29,11 @@ npm install --save @devcycle/react-client-sdk
 yarn add @devcycle/react-client-sdk
 ```
 
-### Using With Create-React-App
+### Using With React 17
+For React 17.x, there is an underlying issue for how the React Runtime is resolved.
 
-Due to [a known issue with create-react-app and cjs](https://github.com/facebook/create-react-app/pull/12021#issuecomment-1108426483), the following steps are required to ensure compatibility with the SDK.
+The interim fix, is to add an alias resolution to your build configuration for `'react/jsx-runtime': require.resolve('react/jsx-runtime')`.
 
-**1. Install [react-app-rewired](https://github.com/timarney/react-app-rewired)**
+For more information, please review these Github Issues [React Issue](https://github.com/facebook/react/issues/20235), [Create React App Issue](https://github.com/facebook/create-react-app/issues/11769) & related PR [React Runtime PR](https://github.com/facebook/create-react-app/pull/11797).
 
-```
-yarn add react-app-rewired --dev
-```
-
-or
-
-```
-npm install react-app-rewired --save-dev
-```
-
-**2. Create a file at the root of your project called `config-overrides.js`**
-
-```
-// config-overrides.js
-module.exports = {
-    webpack: function (config, env) {
-        config.module.rules = config.module.rules.map((rule) => {
-            if (rule.oneOf instanceof Array) {
-                rule.oneOf[rule.oneOf.length - 1].exclude = [
-                    /\.(js|mjs|jsx|cjs|ts|tsx)$/,
-                    /\.html$/,
-                    /\.json$/,
-                ]
-            }
-            return rule
-        })
-        return config
-    },
-}
-```
-
-**3. Update the `scripts` section of your `package.json` to use `react-app-rewired`**
-
-```
-/* package.json */
-
-  "scripts": {
--   "start": "react-scripts start",
-+   "start": "react-app-rewired start",
--   "build": "react-scripts build",
-+   "build": "react-app-rewired build",
--   "test": "react-scripts test",
-+   "test": "react-app-rewired test",
-    "eject": "react-scripts eject"
-}
-```
+For additional help, please contact DevCycle support at [support@devcycle.com](mailto:support@devcycle.com).


### PR DESCRIPTION
- Remove Create react App workaround because it is no longer necessary
- move React 17 warning to the end of the installation so its not the first thing you see