### PR TITLE
fix: adds Events API Proxy Option for iOS and Android SDKs

### DIFF
--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -5,8 +5,7 @@ sidebar_position: 11
 
 This guide explains how to set up and use the DevCycle Slack app.
 
-You can use the DevCycle Slack app to keep track of and monitor feature flags within your team's Slack workspace. 
-
+You can use the DevCycle Slack app to keep track of and monitor feature flags within your team's Slack workspace.
 
 ## Setup
 
@@ -14,34 +13,34 @@ You can use the DevCycle Slack app to keep track of and monitor feature flags wi
 
 ![Screenshot of Integrations tab on dashboard](/apr-2024-slack1.png)
 
-2. Click on the `Add to Slack` button and connect the DevCycle Slack app with your  workspace. 
+2. Click on the `Add to Slack` button and connect the DevCycle Slack app with your workspace.
 
 ![Screenshot of Integrations tab on dashboard](/apr-2024-slack2.png)
 
-3. Once the DevCycle app has been added, you can now subscribe to Feature changes on a project-level or by individual Feature(s). 
-4. First, navigate to the Slack channel where you would like to have the Slack messages to be posted. 
-    - To add a subscription for project-level changes, use the command  `/devcycle subscribe [project-key]`. To find a project's respective key, go to your organization's [Project Settings page](https://app.devcycle.com/r/settings/projects) and copy the key under the Project name.
-    ![Screenshot of Integrations tab on dashboard](/apr-2024-slack6.png)
-    - To add a subscription for individual feature changes, use the command `/devcycle subscribe [project-key] [feature-key]`. 
+3. Once the DevCycle app has been added, you can now subscribe to Feature changes on a project-level or by individual Feature(s).
+4. First, navigate to the Slack channel where you would like to have the Slack messages to be posted.
+
+   - To add a subscription for project-level changes, use the command `/devcycle subscribe [project-key]`. To find a project's respective key, go to your organization's [Project Settings page](https://app.devcycle.com/r/settings/projects) and copy the key under the Project name.
+     ![Screenshot of Integrations tab on dashboard](/apr-2024-slack6.png)
+   - To add a subscription for individual feature changes, use the command `/devcycle subscribe [project-key] [feature-key]`.
 
 5. Once you've susbcribed, you're all set! Go ahead and make some changes to a Feature then check your Slack Channel for notifications.
 
-## Example Slack Message 
+## Example Slack Message
+
 ![Screenshot of Slack Message](/apr-2024-slack5.png)
 
-The `View Project [Name]` button will take you to the project that the Feature belongs to. 
+The `View Project [Name]` button will take you to the project that the Feature belongs to.
 
-The `View Changes on Feature [Feature Name]` will take you to the Audit Log entry with more details about the Feature modification. 
+The `View Changes on Feature [Feature Name]` will take you to the Audit Log entry with more details about the Feature modification.
 
-## Slack Commands 
-- `/devcycle [ subscribe | unsubscribe | list ]`
-- `/dvc [ subscribe | unsubscribe | list ]`
+## Slack Commands
 
-## Uninstall the DevCycle Slack App 
+- `/devcycle [ subscribe | unsubscribe | list | help ]`
+- `/dvc [ subscribe | unsubscribe | list | help ]`
 
-In the case that you connected your Slack app to the wrong workspace or would like to remove it, please follow the instructions in this [Slack Help Center article](https://slack.com/help/articles/360003125231-Remove-apps-and-custom-integrations-from-your-workspace#remove-an-app). 
+## Uninstall the DevCycle Slack App
+
+In the case that you connected your Slack app to the wrong workspace or would like to remove it, please follow the instructions in this [Slack Help Center article](https://slack.com/help/articles/360003125231-Remove-apps-and-custom-integrations-from-your-workspace#remove-an-app).
 
 ![How to Remove DevCycle Slack App](/apr-2024-slack-uninstall.png)
-
-
-

--- a/docs/sdk/client-side-sdks/android/android-gettingstarted.md
+++ b/docs/sdk/client-side-sdks/android/android-gettingstarted.md
@@ -111,6 +111,8 @@ The SDK exposes various initialization options which can be used by passing a `D
 | configCacheTTL               | Long      | 604800000 | The maximum allowed age of a cached config in milliseconds, defaults to 7 days                                 |
 | disableConfigCache           | Boolean   | false     | Disable the use of cached configs                                                                              |
 | disableRealtimeUpdates       | Boolean   | false     | Disable Realtime Updates                                                                                       |
+| apiProxyURL                  | String    | null      | Allows the SDK to communicate with a proxy of DevCycle Client SDK API.                                         |
+| eventsApiProxyURL            | String    | null      | Allows the SDK to communicate with a proxy of DevCycle Events API.                                             |
 
 ## Notifying when DevCycle features are available
 

--- a/docs/sdk/client-side-sdks/flutter/flutter-gettingstarted.md
+++ b/docs/sdk/client-side-sdks/flutter/flutter-gettingstarted.md
@@ -94,6 +94,8 @@ The SDK exposes various initialization options which can be used by passing a `D
 | configCacheTTL               | Int       | 604800000 | The maximum allowed age of a cached config in milliseconds, defaults to 7 days                                 |
 | disableConfigCache           | Bool      | false     | Disable the use of cached configs                                                                              |
 | disableRealtimeUpdates       | Bool      | false     | Disable Realtime Updates                                                                                       |
+| apiProxyURL                  | String    | null      | Allows the SDK to communicate with a proxy of DevCycle Client SDK API.                                         |
+| eventsApiProxyURL            | String    | null      | Allows the SDK to communicate with a proxy of DevCycle Events API.                                             |
 
 ## Notifying when DevCycle features are available
 

--- a/docs/sdk/client-side-sdks/ios/ios-gettingstarted.md
+++ b/docs/sdk/client-side-sdks/ios/ios-gettingstarted.md
@@ -115,7 +115,8 @@ The SDK exposes various initialization options which can be used by passing a `D
 | configCacheTTL               | Int       | 604800000 | The maximum allowed age of a cached config in milliseconds, defaults to 7 days                                 |
 | disableConfigCache           | Bool      | false     | Disable the use of cached configs                                                                              |
 | disableRealtimeUpdates       | Bool      | false     | Disable Realtime Updates                                                                                       |
-| apiProxyURL                  | String    | nil       | Allows the SDK to communicate with a proxy of DevCycle Bucketing API / Client SDK API.                         |
+| apiProxyURL                  | String    | nil       | Allows the SDK to communicate with a proxy of DevCycle Client SDK API.                                         |
+| eventsApiProxyURL            | String    | nil       | Allows the SDK to communicate with a proxy of DevCycle Events API.                                             |
 
 ## Notifying when DevCycle features are available
 


### PR DESCRIPTION
- updates DevCycle Options to include API Proxy and Events API Proxy for Android, iOS and Flutter SDKs