### PR TITLE
fix: update minimum Android API Version to 23 instead of 21

### DIFF
--- a/docs/sdk/client-side-sdks/android/android-install.md
+++ b/docs/sdk/client-side-sdks/android/android-install.md
@@ -11,7 +11,7 @@ sidebar_custom_props: { icon: material-symbols:install-desktop }
 
 ## Requirements
 
-This version of the DevCycle Android Client SDK supports a minimum Android API Version 21.
+This version of the DevCycle Android Client SDK supports a minimum Android API Version 23.
 
 :::info
 **Proguard/R8:** If minifying your project, DevCycle requires **Android Gradle Plugin 7.1.x or higher**

--- a/docs/sdk/client-side-sdks/flutter/flutter-install.md
+++ b/docs/sdk/client-side-sdks/flutter/flutter-install.md
@@ -11,7 +11,7 @@ sidebar_custom_props: { icon: material-symbols:install-desktop }
 
 ## Requirements
 
-This version of the DevCycle Flutter Client SDK requires a minimum of version of Flutter 2.5.0 (dart 2.14.0), iOS 13.7 and Android API Version 26.
+This version of the DevCycle Flutter Client SDK requires a minimum of version of Flutter 2.5.0 (dart 2.14.0), iOS 13.7 and Android API Version 23.
 
 ## Installation
 
@@ -26,7 +26,7 @@ The SDK can be installed into your Flutter project by running `flutter pub add d
 The SDK can be installed into your Flutter project by adding the following to your `pubspec.yaml`:
 
 ```dart
-devcycle_flutter_client_sdk: ^1.1.0
+devcycle_flutter_client_sdk: ^1.8.0
 ```
 
 Then, run `flutter pub get`.


### PR DESCRIPTION
- updates minimum Android API Version to 23 (was 21 on Android SDK and 26 on Flutter SDK)
- updates Flutter SDK install version to `^1.8.0`