### PR TITLE
chore: fix typos and spelling mistakes in quickstart

### DIFF
--- a/docs/introduction/quickstart.md
+++ b/docs/introduction/quickstart.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 This page will guide you through the initial setup steps with DevCycle.
 
-Whether you follow our guided onboarding flow, or you skip ahead to the dashboard to explore on your own, this quickstart guide will get you up and running with a Free Account and functional Feature Flags in just a couple minutes.
+Whether you follow our guided onboarding flow, or you skip ahead to the dashboard to explore on your own, this quickstart guide will get you up and running with a Free Account and functional feature flags in just a couple minutes.
 
 https://www.youtube.com/watch?v=bZD-pyKGwR4
 
@@ -15,7 +15,7 @@ https://www.youtube.com/watch?v=bZD-pyKGwR4
 
 ### Sign Up
 
-If you don't yet have an account with DevCycle that's not a problem! [Simply make a completely free account right here.](https://app.devcycle.com/?isSignUp=true)
+If you don't yet have an account with DevCycle, that's not a problem! [Simply make a completely free account right here.](https://app.devcycle.com/?isSignUp=true)
 
 We have an always free tier to start and the pricing will scale with usage as you need. You can create a free account right away, and if you're curious about our pricing, [check it out here](https://devcycle.com/pricing).
 
@@ -29,7 +29,7 @@ Once you have verified your email you will be prompted to provide your name and 
 
 ### Role and Tech Stack
 
-To better guide you through onboarding, we also ask you to identify your role and the tech stack you primarily work with in your Organization. In this way we can customize the onboarding flow as well as guide you toward the code and example apps that should make the most sense for your needs.
+To better guide you through onboarding, we also ask you to identify your role and the tech stack you primarily work with in your Organization. In this way we can customize the onboarding flow as well as guide you toward the code and example apps that makes the most sense for your needs.
 
 ---
 
@@ -37,7 +37,7 @@ Once you enter a role and your stack you'll be presented with a choice to either
 
 ## Guided Onboarding
 
-The guided onboarding experience leverages our example apps and a focused set of steps to have you up and running with some example Feature Flags in a matter of minutes. This flow intends to help you understand the core concepts behind DevCycle. Once you are done this onboarding flow, you'll have a fully functional set of Feature Flags created in your dashboard connected to a running example app that you can then explore further on your own before implementing into your own code.
+The guided onboarding experience leverages our example apps and a focused set of steps to have you up and running with some example feature flags in a matter of minutes. This flow intends to help you understand the core concepts behind DevCycle. Once you are done this onboarding flow, you'll have a fully functional set of feature flags created in your dashboard connected to a running example app that you can then explore further on your own before implementing into your own code.
 
 ### Select Language
 
@@ -49,13 +49,13 @@ Once you've selected an example app we'll provide you with the way to install, b
 
 ### Learn About Variables, Variations and Targeting
 
-While DevCycle has a lot of unique features, some of the most important ones are how we organize and target Feature Flags to users. In DevCycle we call Feature Flags Variables. Variables live in your code and allow you to build conditionals around the values they retrieve. Variables are organized within Features in DevCycle. Features can contain one or many Variables and are the vehicle by which Variables are configured, using Variations. Variations determine a set of values to deliver to each Variable within a Feature. Which Variation a user receives is determined by Targeting Rules.
+While DevCycle has a lot of unique features, some of the most important ones are how we organize and target feature flags to users. In DevCycle we call feature flags Variables. Variables live in your code and allow you to build conditionals around the values they retrieve. Variables are organized within Features in DevCycle. Features can contain one or many Variables and are the vehicle by which Variables are configured, using Variations. Variations determine a set of values to deliver to each Variable within a Feature. Which Variation a user receives is determined by Targeting Rules.
 
 The onboarding guide steps you through Variables, Variations and Targeting to ensure these base concepts are clear.
 
 ### Toggle A Variation
 
-As you can see the example app starts with a number of Variables already configured within the dashboard. To Toggle your first Variation within DevCycle follow the instructions to choose a new Variation and observe the change in the example app you're running.
+As you can see the example app starts with a number of Variables already configured within the dashboard. To toggle your first Variation within DevCycle follow the instructions to choose a new Variation and observe the change in the example app you're running.
 
 ### Create Your Own Variation
 
@@ -65,7 +65,7 @@ Now that you've toggled between Variations you can go back and create a Variatio
 
 That's it! You've done the most important actions in DevCycle.
 
-What you have now is a fully functioning app, set up with Feature Flags, connected to your Project. You can now continue to the main dashboard and play around with the example app and its connected Feature however you'd like.
+What you have now is a fully functioning app, set up with feature flags, connected to your Project. You can now continue to the main dashboard and play around with the example app and its connected Feature however you'd like.
 
 We'd suggest playing around with Targeting Rules and different user properties to customize how Variations are delivered.
 
@@ -102,7 +102,7 @@ The way Variables are delivered different values to different users is via Targe
 The last step is to toggle between different Variations. If you have take the initial Targeting 
 Rule that was set up for the example app that is targeting a Variation to All Users you can switch the Variation that is being served to whatever you would like. Hit save and the example app should now reflect the change you just made.
 
-That's it! That's the core functionality of DevCycle in a nutshell. You've just set up and toggled some Feature Flags running in a live app.
+That's it! That's the core functionality of DevCycle in a nutshell. You've just set up and toggled some feature flags running in a live app.
 
 ---
 
@@ -126,7 +126,7 @@ To create a Feature:
 
 3. After choosing a type, the modal will progress to allow you to name and describe your Feature where you will be prompted to enter:
 
-    **a. A descriptive Feature mame**
+    **a. A descriptive Feature name**
 
     **b. A unique Feature key.** This key is how the Feature and its Variables will be referenced in code. (A key will be automatically suggested based on the entered name.)
 
@@ -150,7 +150,7 @@ Now that you have a Feature created, its time to install the SDK and implement y
 
 **1. Install the DevCycle SDK via the relevant dependency manager.** For example, the react SDK is installed via npm: ```npm i @devcycle/react-client-sdk```
 
-**2. Import DevCycle and initialize it.** Depending on which [type of SDK](/sdk/) and which environment you are initializing for, the SDK Key the SDK is initialized with will be different. Read more about [Environments](/essentials/environments) and [keys](/essentials/keys) in the essentials.
+**2. Import DevCycle and initialize it.** Depending on which [type of SDK](/sdk/) and which environment you are initializing for, the SDK Key will be different. Read more about [Environments](/essentials/environments) and [keys](/essentials/keys) in the essentials.
 
 **3. Access your Variable.** Implement the code to evaluate the Variable that is being controlled by the Feature you just created. Read more about Variables [here](/essentials/variables).
 
@@ -160,14 +160,14 @@ Deeper documentation can be found in the relevant SDK docs. Depending on your us
 
 ### Adjust Variables and Variations
 
-If you'd like, you can edit the values of the Variables and Variations that were auto-populated after creating your Feature or you can create any other Variations that you would like. Variations are the set of values that will be delivered to the example app and all of the Variables are already connected so you can feel free to edit these in any way.
+You can edit the values of the Variables and Variations that were auto-populated after creating your Feature or you can create any other Variations that you would like. Variations are the set of values that will be delivered to the example app and all of the Variables are already connected so you can feel free to edit these in any way.
 
 ### Modify Targeting
 
-The way Variables are delivered different values to different users is via Targeting Rules. The Feature creation process will have created some initial Targeting Rules, but feel free to modify these however you'd like. Just make sure that Targeting is enabled and you have at least one Targeting Rule targeting All Users in the Environment you chose when initializing the SDK. If you would like to try targeting off of user data, you can check out the documentation on [Custom Properties here](/extras/advanced-targeting/custom-properties).
+The way Variables are delivered different values to different users is via Targeting Rules. The Feature creation process will have created some initial Targeting Rules, but you can modify these however you'd like. Just make sure that Targeting is enabled, and you have at least one Targeting Rule targeting "All Users" in the Environment you chose when initializing the SDK. If you would like to try targeting off of user data, you can check out the documentation on [Custom Properties here](/extras/advanced-targeting/custom-properties).
 
 ### Toggle Variations
 
 The last step is to toggle between different Variations. Either take one of the initial Targeting Rules that was created or one you just created and switch the Variation that is being served to whatever you would like. Hit save and your application should now reflect the change you just made.
 
-That's it! That's the core functionality of DevCycle in a nutshell. You've just set up and toggled some Feature Flags running in your own app.
+That's it! That's the core functionality of DevCycle in a nutshell. You've just set up and toggled some feature flags running in your own app.


### PR DESCRIPTION
# Changes

- refactor `Feature Flags` to `feature flags`
- fix spelling mistakes
- reword a couple of awkward sentences
