### PR TITLE
chore: added note for package url conflicts

### DIFF
--- a/docs/sdk/client-side-sdks/ios/ios-install.md
+++ b/docs/sdk/client-side-sdks/ios/ios-install.md
@@ -56,6 +56,10 @@ Drag the built .xcframework bundles from Carthage/Build into the "Frameworks and
 
 ### Swift Package Manager
 
+:::info
+**Package URL Conflicts:** If you have a package that conflicts with the naming of the `ios-client-sdk`, then you can use https://github.com/DevCycleHQ/devcycle-ios-client-sdk.git.
+:::
+
 To use the library with Swift Package Manager, include it as a dependency in your `Package.swift` file like so:
 
 ```


### PR DESCRIPTION
# Changes

- added note for alias of package for SPM
<img width="982" alt="Screenshot 2024-07-29 at 11 32 06 AM" src="https://github.com/user-attachments/assets/0139d608-98ed-47a0-ba42-03ed5ee36dd2">



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
