### PR TITLE
feat: update realtime update docs

### DIFF
--- a/docs/sdk/features.md
+++ b/docs/sdk/features.md
@@ -3,8 +3,8 @@ title: Features and Functionality
 sidebar_position: 1
 ---
 
-DevCycle strives to ensure that all our APIs and SDKs have identical functionality 
-(except language- or platform-specific nuances). Below is a list of all the current 
+DevCycle strives to ensure that all our APIs and SDKs have identical functionality
+(except language- or platform-specific nuances). Below is a list of all the current
 functionality that DevCycle supports across the SDKs.
 
 **Universal**
@@ -15,11 +15,11 @@ functionality that DevCycle supports across the SDKs.
 - [Getting All Variables](#getting-all-variables)
 - [Identifying Users / Setting Properties](#identifying-a-user-or-setting-properties)
 - [Tracking Events](#tracking-custom-events)
+- [Realtime Updates](#realtime-updates)
 
 **Limited**
 
 - [Custom Domains](#custom-domains)
-- [Realtime Updates](#realtime-updates)
 
 ## Initialization
 
@@ -31,6 +31,7 @@ The current user is determined by you, and should contain any details about the 
 logic.
 
 A typical initialization call looks like this
+
 ```typescript
 const devcycleClient = initializeDevCycle('<DEVCYCLE_CLIENT_SDK_KEY>', user)
 ```
@@ -39,6 +40,7 @@ SDKs also offer a way to wait for initialization to finish, meaning that the Dev
 and the SDK is ready to return the correct variable values for the given user.
 
 Here is a Javascript example:
+
 ```typescript
 // wait for client to initialize
 await devcycleClient.onClientInitialized()
@@ -48,20 +50,22 @@ await devcycleClient.onClientInitialized()
 
 When initialized, each client-side SDK will cache the retrieved configuration for the user.
 
-This cache will be used in scenarios where on subsequent initializations a new configuration is not available. 
+This cache will be used in scenarios where on subsequent initializations a new configuration is not available.
 This may be due to a lack of internet connection or a lack of connection to DevCycle.
 
-Additionally, if the SDK is interacted with before any initialization (such as attempting to read a variable far 
+Additionally, if the SDK is interacted with before any initialization (such as attempting to read a variable far
 early on in an application before initialization), the cached value will be read.
 
-If a variable is first read from the cache and has a listener for [realtime updates](#realtime-updates), if a 
+If a variable is first read from the cache and has a listener for [realtime updates](#realtime-updates), if a
 new value is retrieved after initialization, the `onUpdate` function will be triggered.
 
 ### Server-Side SDKs
+
 For most server-side SDKs, the only required parameter to initialize the SDK is the SDK Key.
 The SDK key is unique to each project and environment and can be found in the DevCycle dashboard.
 
 A typical initialization call looks like this
+
 ```typescript
 const devcycleClient = initializeDevCycle('<DEVCYCLE_SERVER_SDK_KEY>')
 ```
@@ -70,6 +74,7 @@ SDKs also offer a way to wait for initialization to finish, meaning that the Dev
 and the SDK is ready to return the correct variable values for the given user.
 
 Here is a Javascript example:
+
 ```typescript
 // wait for client to initialize
 await devcycleClient.onClientInitialized()
@@ -77,10 +82,10 @@ await devcycleClient.onClientInitialized()
 
 ## Evaluating Features & Using Variables
 
-This section explains how to use retrieve the Variables of a Feature as well as use their values. For information 
+This section explains how to use retrieve the Variables of a Feature as well as use their values. For information
 on setting up a Feature for use, read [Variables and Variations](/platform/feature-flags/variables-and-variations/variables) and [Targeting Users](/platform/feature-flags/targeting/targeting-overview)
 
-Every SDK provides a method to retrieve a Variable's value. It expects to receive the unique key of the Variable, 
+Every SDK provides a method to retrieve a Variable's value. It expects to receive the unique key of the Variable,
 and a default value to serve in case no other value is available.
 
 A typical Variable method would look something like this:
@@ -94,7 +99,7 @@ const myVariableValue = devcycleClient.variableValue(
 )
 ```
 
-Each call to this method is tracked as an "evaluation" event. These events will be shown in the DevCycle dashboard and 
+Each call to this method is tracked as an "evaluation" event. These events will be shown in the DevCycle dashboard and
 are used to power the analytics graphs that allow you to see the effects of your Variables being used.
 
 The default value will be returned in the following scenarios:
@@ -131,7 +136,7 @@ The response is the following general format, with slight changes depending on t
 }
 ```
 
-Only Features that the User has satisfied [targeting rules](/platform/feature-flags/targeting/targeting-overview) for will be returned by this function. 
+Only Features that the User has satisfied [targeting rules](/platform/feature-flags/targeting/targeting-overview) for will be returned by this function.
 The feature must also be **enabled** for that environment.
 
 ## Getting all Variables
@@ -157,7 +162,7 @@ The response is the following general format, with slight changes depending on t
 }
 ```
 
-Only Variables in Features that the user has satisfied [targeting rules](/platform/feature-flags/targeting/targeting-overview) for will be part of the response in this method. 
+Only Variables in Features that the user has satisfied [targeting rules](/platform/feature-flags/targeting/targeting-overview) for will be part of the response in this method.
 The Feature must also be **enabled** for the environment this SDK is being called on.
 
 :::caution
@@ -212,7 +217,7 @@ corresponding to that user. A typical call to this method looks like
 
 ```typescript
 const user = {
-  user_id: 'myUser'
+  user_id: 'myUser',
 }
 
 await devCycleClient.identifyUser(user)
@@ -220,20 +225,21 @@ await devCycleClient.identifyUser(user)
 
 The `identifyUser` method always includes a way to wait for the operation to finish. When finished, the SDK will have
 the correct configuration for the given user and all Variable evaluations from that point onward will be based on the
-new user's data. This method is useful when user data can not be known at initialization time, or when the user's 
+new user's data. This method is useful when user data can not be known at initialization time, or when the user's
 identity must be changed during the application's lifecycle.
 
 #### Anonymous Users
 
 :::info
 
-If a user id is not supplied, client-side SDKs will automatically generate a user id and assign it to the current user. 
-This id will be cached and used between app sessions / website visits until a user id is supplied or [reset](#reset-user) is 
+If a user id is not supplied, client-side SDKs will automatically generate a user id and assign it to the current user.
+This id will be cached and used between app sessions / website visits until a user id is supplied or [reset](#reset-user) is
 called. This will ensure you will not experience a rise in MAUs if the main experience of your application is in a logged-out or anonymous state.
 
 :::
 
 #### Resetting a User
+
 Client SDKs also contain a method for "resetting" a user's identity. This can be used in cases like "logging out", where there is no longer
 any identifiable information to pass to the SDK. In those cases, "reset" will clear all stored data and generate a new "anonymous" user ID
 to represent the user.
@@ -244,25 +250,25 @@ User data can also contain "custom data", which is a key-value map of any arbitr
 The provided data can be used in Targeting Rules by creating Custom Properties in the DevCycle dashboard. Learn more
 about [Custom Property Targeting](/platform/feature-flags/targeting/custom-properties)
 
-When setting custom properties you have a choice between keeping that data completely private or allowing 
-for the data to be logged back to DevCycle's events database. Both options allow for the same targeting capabilities, 
+When setting custom properties you have a choice between keeping that data completely private or allowing
+for the data to be logged back to DevCycle's events database. Both options allow for the same targeting capabilities,
 but you should use Private Custom Data if you are looking to avoid having user data saved to any external system.
 
-With Private Custom Data, data is used solely for targeting decisions within DevCycle's Edge Workers. 
+With Private Custom Data, data is used solely for targeting decisions within DevCycle's Edge Workers.
 It is then discarded and no record is saved anywhere.
 
-With regular Custom Data, the data used for evaluation purposes is logged back to DevCycle's events database where 
+With regular Custom Data, the data used for evaluation purposes is logged back to DevCycle's events database where
 it can be used for debugging purposes or providing guidance on evaluation reasons.
 
 #### Server-Side SDK Identification
 
-Unlike the Client-Side SDKs, Server-Side SDKs work in a multi-user context. 
-Because of this, a single Identify function does not make sense. 
+Unlike the Client-Side SDKs, Server-Side SDKs work in a multi-user context.
+Because of this, a single Identify function does not make sense.
 Instead, you must provide the user data to each function call when evaluating variables. For example:
 
 ```typescript
 const user = {
-    user_id: 'myUser'
+  user_id: 'myUser',
 }
 
 const myVariableValue = devcycleClient.variableValue(
@@ -271,7 +277,7 @@ const myVariableValue = devcycleClient.variableValue(
   // Variable "key"
   'my-variable-key',
   // Default value to use if DevCycle has no other value
-  'default-value'
+  'default-value',
 )
 ```
 
@@ -285,7 +291,7 @@ and metrics on A/B tests and experiments within the DevCycle dashboard.
 
 ## Custom Domains
 
-When using client-side SDKs, particularly web client SDKs there is the potential for Ad Blockers 
+When using client-side SDKs, particularly web client SDKs there is the potential for Ad Blockers
 and browser privacy features to block requests and third-party cookies. Custom Domains with DevCycle ensures
 all cookies and requests used are first-party and will not be blocked by ensuring requests are sent through your
 recognized domain. A DNS CNAME needs to be created to leverage this feature.
@@ -304,23 +310,8 @@ For instructions on setting up a custom domain, see [Custom Domains](/platform/e
 
 All DevCycle SDKs are capable of being notified in realtime that new configuration changes have been made in the DevCycle platform.
 DevCycle leverages Server-Sent Events (SSE) to notify the SDKs that a feature (targeting rules, variable values, etc.)
-has been updated and that they should fetch the new configuration. A connection URL is included in the config that the SDK fetches, 
+has been updated and that they should fetch the new configuration. A connection URL is included in the config that the SDK fetches,
 triggering the SDK to open a connection with our SSE provider and listen for any changes in the given environment.
-
-**Supported SDKs**
-- Javascript
-- React
-- iOS
-- Android
-- Flutter
-- NodeJS (including Nest)
-- Next.js
-- Python
-- Ruby
-- Java
-- Go
-- .NET
-- PHP (via SDK Proxy)
 
 ### SDK Specifics
 
@@ -335,7 +326,6 @@ If the user backgrounds the application for some period of time, the SDK will di
 #### Server-Side SDKs
 
 If the server loses its connection it will be re-opened it will be re-opened automatically after a configurable interval.
-
 
 ## Local and Cloud Bucketing
 

--- a/docs/sdk/server-side-sdks/dotnet/dotnet-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/dotnet/dotnet-gettingstarted.md
@@ -123,21 +123,21 @@ namespace Example {
 }
 ```
 
-| DevCycle Option              | Type           | Description                                                                                                                                                                  |
-|------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| enableEdgeDB                 | bool        | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. <br />NOTE: This is only available with Cloud Bucketing enabled.                                          |
-| configPollingIntervalMs      | int         | Controls the polling interval in milliseconds to fetch new environment config changes, defaults to 10 seconds, minimum value is 1 second.                                    |
-| configPollingTimeoutMs       | int         | Controls the request timeout to fetch new environment config changes, defaults to 5 seconds, must be less than the configPollingIntervalMS value, minimum value is 1 second. |
-| disableAutomaticEvents | bool        | Disables logging of sdk generated events (e.g. aggVariableEvaluated, aggVariableDefaulted) to DevCycle.                                                                      |
-| disableCustomEvents    | bool        | Disables logging of custom events, from `track()` method, and user data to DevCycle.                                                                                         |
-| flushEventQueueSize          | int         | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                           |
-| maxEventsInQueue            | int         | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                                          |
-| eventRequestChunkSize            | int         | Count of events to chunk per event upload request. Defaults to `100`.                                                                          |
-| eventFlushIntervalMs            | int         | Controls the interval between flushing events to the DevCycle servers. Defaults to `10000`.                                                                          |
-| cdnUri                  | string         | Contact support for usage instructions.                                                                                       |
-| cdnSlug                  | string         | Contact support for usage instructions.                                                                                       |
-| eventsApiUri                  | string         | Contact support for usage instructions.                                                                                    |
-| eventsApiSlug                  | string         | Contact support for usage instructions.                                                                                     |
-| cdnCustomHeaders                  | Dictionary         | Contact support for usage instructions.                                                                                       |
-| eventsApiCustomHeaders                  | Dictionary         | Contact support for usage instructions.                                                                                       |
-| enableBetaRealtimeUpdates    | bool        | Enables the usage of Beta Realtime Updates for DevCycle. This feature is currently in beta.                                                                                  |
+| DevCycle Option         | Type       | Description                                                                                                                                                                  |
+| ----------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| enableEdgeDB            | bool       | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. <br />NOTE: This is only available with Cloud Bucketing enabled.                                  |
+| configPollingIntervalMs | int        | Controls the polling interval in milliseconds to fetch new environment config changes, defaults to 10 seconds, minimum value is 1 second.                                    |
+| configPollingTimeoutMs  | int        | Controls the request timeout to fetch new environment config changes, defaults to 5 seconds, must be less than the configPollingIntervalMS value, minimum value is 1 second. |
+| disableAutomaticEvents  | bool       | Disables logging of sdk generated events (e.g. aggVariableEvaluated, aggVariableDefaulted) to DevCycle.                                                                      |
+| disableCustomEvents     | bool       | Disables logging of custom events, from `track()` method, and user data to DevCycle.                                                                                         |
+| flushEventQueueSize     | int        | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                           |
+| maxEventsInQueue        | int        | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                                          |
+| eventRequestChunkSize   | int        | Count of events to chunk per event upload request. Defaults to `100`.                                                                                                        |
+| eventFlushIntervalMs    | int        | Controls the interval between flushing events to the DevCycle servers. Defaults to `10000`.                                                                                  |
+| cdnUri                  | string     | Contact support for usage instructions.                                                                                                                                      |
+| cdnSlug                 | string     | Contact support for usage instructions.                                                                                                                                      |
+| eventsApiUri            | string     | Contact support for usage instructions.                                                                                                                                      |
+| eventsApiSlug           | string     | Contact support for usage instructions.                                                                                                                                      |
+| cdnCustomHeaders        | Dictionary | Contact support for usage instructions.                                                                                                                                      |
+| eventsApiCustomHeaders  | Dictionary | Contact support for usage instructions.                                                                                                                                      |
+| disableRealtimeUpdates  | bool       | Disables realtime update SSE connections for DevCycle, reverts back to polling against the config CDN.                                                                       |

--- a/docs/sdk/server-side-sdks/dotnet/dotnet-usage.md
+++ b/docs/sdk/server-side-sdks/dotnet/dotnet-usage.md
@@ -10,7 +10,7 @@ sidebar_custom_props: { icon: material-symbols:toggle-on }
 [![Nuget Local](https://badgen.net/nuget/v/DevCycle.SDK.Server.Cloud)](https://www.nuget.org/packages/DevCycle.SDK.Server.Local/)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/dotnet-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/dotnet-server-sdk)
 
-[//]: # (wizard-evaluate-start)
+[//]: # 'wizard-evaluate-start'
 
 ## DevCycleUser Object
 
@@ -31,7 +31,8 @@ In that case it will return a variable value with the value set to whatever was 
 ```csharp
 bool result = await client.VariableValue(user, "your-variable-key", true);
 ```
-[//]: # (wizard-evaluate-end)
+
+[//]: # 'wizard-evaluate-end'
 
 The default value can be of type `String`, `Boolean`, `Number`, or `Object`.
 
@@ -50,7 +51,7 @@ Dictionary<string, ReadOnlyVariable<object>> result = await client.AllVariables(
 
 :::caution
 
-This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+This method is intended to be used for debugging and analytics purposes, _not_ as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
 Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
 of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
@@ -114,7 +115,7 @@ This feature reduces the number of polling requests that are made to the DevCycl
 use a long-lived HTTP connection (Server Sent Events) to receive updates when there is a new config available.
 This reduces outbound network traffic, as well as optimizes the SDK for efficiency.
 
-To disable realtime updates, pass in the `disable_realtime_updates` option to the SDK initialization:
+To disable realtime updates, pass in the `disableRealtimeUpdates` option to the SDK initialization:
 
 ```csharp
     client = new DevCycleLocalClientBuilder()

--- a/docs/sdk/server-side-sdks/dotnet/dotnet-usage.md
+++ b/docs/sdk/server-side-sdks/dotnet/dotnet-usage.md
@@ -108,22 +108,18 @@ or the SDK is not able to make requests to the DevCycle API directly. The instal
 
 See the [SDK Proxy](../../sdk-proxy/index.md) section for more information.
 
-## Enabling Beta Realtime Updates
+## Realtime Updates
 
-:::warning
-This feature is in beta, and may not function as expected. Please ensure that you have the latest version of the SDK.
-:::
-
-This functionality will reduce the number of polling requests that are made to the DevCycle Config CDN, and instead will
+This feature reduces the number of polling requests that are made to the DevCycle Config CDN, and instead will
 use a long-lived HTTP connection (Server Sent Events) to receive updates when there is a new config available.
 This reduces outbound network traffic, as well as optimizes the SDK for efficiency.
 
-To enable Beta Realtime Updates, pass in the `enableBetaRealtimeUpdates` option to the SDK initialization:
+To disable realtime updates, pass in the `disable_realtime_updates` option to the SDK initialization:
 
 ```csharp
     client = new DevCycleLocalClientBuilder()
         .SetSDKKey("<DEVCYCLE_SERVER_SDK_KEY>")
-        .SetOptions(new DevCycleLocalOptions(enableBetaRealtimeUpdates: true))
+        .SetOptions(new DevCycleLocalOptions(disableRealtimeUpdates: true))
         .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))
         .Build();
 ```

--- a/docs/sdk/server-side-sdks/go/go-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/go/go-gettingstarted.md
@@ -86,7 +86,7 @@ import (
 func main() {
 	sdkKey := os.Getenv("DEVCYCLE_SERVER_SDK_KEY")
 
-	options := devcycle.Options{ 
+	options := devcycle.Options{
 		// Insert Options
 	}
 
@@ -96,23 +96,22 @@ func main() {
 	}
 }
 ```
-```
 
-| DevCycle Option              | Type           | Description                                                                                                                                                                  |
-|------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Logger                       | util.Logger | Logger override to replace default logger                                                              |
-| EnableEdgeDB                 | bool        | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. <br />NOTE: This is only available with Cloud Bucketing enabled.                                          |
-| EnableCloudBucketing         | bool        | Switches the SDK to use Cloud Bucketing (via the DevCycle Bucketing API) instead of Local Bucketing.                                                                         |
-| EventFlushIntervalMS         | time.Duration         | Controls the interval between flushing events to the DevCycle servers, defaults to 30 seconds.                                                                               |
-| ConfigPollingIntervalMS      | time.Duration         | Controls the polling interval in milliseconds to fetch new environment config changes, defaults to 10 seconds, minimum value is 1 second.                                    |
-| RequestTimeout       | time.Duration         | Controls the request timeout to fetch new environment config changes, defaults to 5 seconds, must be less than the configPollingIntervalMS value, minimum value is 1 second. |
-| DisableAutomaticEventLogging | bool        | Disables logging of sdk generated events (e.g. aggVariableEvaluated, aggVariableDefaulted) to DevCycle.                                                                      |
-| DisableCustomEventLogging    | bool        | Disables logging of custom events, from `track()` method, and user data to DevCycle.                                                                      |
-| DisableETagMatching    | bool        | Contact Support for usage instructions.                                                                      |
-| EnableBetaRealtimeUpdates    | bool        | Enables the usage of Beta Realtime Updates for DevCycle. This feature is currently in beta.                                                                                  |
-| MaxEventQueueSize            | int         | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                                          |
-| FlushEventQueueSize          | int         | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                           |
-| ConfigCDNURI                  | string         | Contact support for usage instructions.                                                                      |
-| EventsAPIURI                  | string         | Contact support for usage instructions.                                                                      |
-| ClientEventHandler                  | api.ClientEvent         | Async initialization callback handler.                                                                      |
-| BucketingAPIURI                  | string         | Contact support for usage instructions.                                                                      |
+| DevCycle Option              | Type            | Description                                                                                                                                                                  |
+| ---------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Logger                       | util.Logger     | Logger override to replace default logger                                                                                                                                    |
+| EnableEdgeDB                 | bool            | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. <br />NOTE: This is only available with Cloud Bucketing enabled.                                  |
+| EnableCloudBucketing         | bool            | Switches the SDK to use Cloud Bucketing (via the DevCycle Bucketing API) instead of Local Bucketing.                                                                         |
+| EventFlushIntervalMS         | time.Duration   | Controls the interval between flushing events to the DevCycle servers, defaults to 30 seconds.                                                                               |
+| ConfigPollingIntervalMS      | time.Duration   | Controls the polling interval in milliseconds to fetch new environment config changes, defaults to 10 seconds, minimum value is 1 second.                                    |
+| RequestTimeout               | time.Duration   | Controls the request timeout to fetch new environment config changes, defaults to 5 seconds, must be less than the configPollingIntervalMS value, minimum value is 1 second. |
+| DisableAutomaticEventLogging | bool            | Disables logging of sdk generated events (e.g. aggVariableEvaluated, aggVariableDefaulted) to DevCycle.                                                                      |
+| DisableCustomEventLogging    | bool            | Disables logging of custom events, from `track()` method, and user data to DevCycle.                                                                                         |
+| DisableETagMatching          | bool            | Contact Support for usage instructions.                                                                                                                                      |
+| DisableRealtimeUpdates       | bool            | Disables the usage of realtime updates SSE connections for DevCycle, will revert to polling against the config CDN.                                                          |
+| MaxEventQueueSize            | int             | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                                          |
+| FlushEventQueueSize          | int             | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                           |
+| ConfigCDNURI                 | string          | Contact support for usage instructions.                                                                                                                                      |
+| EventsAPIURI                 | string          | Contact support for usage instructions.                                                                                                                                      |
+| ClientEventHandler           | api.ClientEvent | Async initialization callback handler.                                                                                                                                       |
+| BucketingAPIURI              | string          | Contact support for usage instructions.                                                                                                                                      |

--- a/docs/sdk/server-side-sdks/go/go-usage.md
+++ b/docs/sdk/server-side-sdks/go/go-usage.md
@@ -158,20 +158,17 @@ In this example, the `Variable` call would make an API request and send along th
 That data would be used in combination with EdgeDB data to make correct bucketing decisions before returning the
 variable's value.
 
+## Realtime Updates
 
-## Enabling Beta Realtime Updates
-:::warning
-This feature is in beta, and may not function as expected. Please ensure that you have the latest version of the SDK.
-:::
+This feature reduces the number of polling requests that are made to the DevCycle Config CDN, and instead will
+use a long-lived HTTP connection (Server Sent Events) to receive updates when there is a new config available.
+This reduces outbound network traffic, as well as optimizes the SDK for efficiency.
 
-This functionality will reduce the number of polling requests that are made to the DevCycle Config CDN, and instead will
-use a long-lived HTTP connection (Server Sent Events) to receive updates when there is a new config available. 
-This reduces outbound network traffic, as well as optimizes the SDK for efficiency. 
+To disable realtime updates, pass in the `DisableRealtimeUpdates` option to the SDK initialization:
 
-To enable Beta Realtime Updates, pass in the `EnableBetaRealtimeUpdates` option to the SDK initialization:
 ```go
 options := devcycle.Options{
-    EnableBetaRealtimeUpdates:    true,
+    DisableRealtimeUpdates:    true,
     // other options omitted for this example
 }
 

--- a/docs/sdk/server-side-sdks/java/java-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/java/java-gettingstarted.md
@@ -56,28 +56,27 @@ public class MyClass {
 
 ### Local Bucketing Options
 
-| DevCycle Option              | Type           | Description                                                                                                                                                                  |
-|------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| customLogger                 | IDevCycleLogger | Logger override to replace default logger                                                                                                                                    |
-| restOptions                  | IRestOptions | Contact support for usage instructions.                                                                                                                                    |
-| configPollingIntervalMS      | int         | Controls the polling interval in milliseconds to fetch new environment config changes, defaults to 30 seconds, minimum value is 1 second.                                    |
-| configPollingTimeoutMs       | int         | Controls the request timeout to fetch new environment config changes, defaults to 10 seconds, must be less than the configPollingIntervalMS value, minimum value is 1 second. |
-| eventFlushIntervalMS         | int         | Controls the interval between flushing events to the DevCycle servers, defaults to 10 seconds.                                                                               |
-| flushEventQueueSize          | int         | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                           |
-| maxEventQueueSize            | int         | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                                          |
-| eventRequestChunkSize        | int         | Count of events to chunk per event upload request. Defaults to `100`.                                                                          |
-| disableAutomaticEventLogging | boolean        | Disables logging of sdk generated events (e.g. aggVariableEvaluated, aggVariableDefaulted) to DevCycle.                                                                      |
-| disableCustomEventLogging    | boolean        | Disables logging of custom events, from `track()` method, and user data to DevCycle.                                                                                         |
-| configCdnBaseUrl             | String         | Contact support for usage instructions.                                                                                  |
-| eventsApiBaseUrl             | String         | Contact support for usage instructions.                                                                                       |
-| enableBetaRealtimeUpdates    | boolean        | Enables the usage of Beta Realtime Updates for DevCycle. This feature is currently in beta.                                                                                  |
-
+| DevCycle Option              | Type            | Description                                                                                                                                                                   |
+| ---------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| customLogger                 | IDevCycleLogger | Logger override to replace default logger                                                                                                                                     |
+| restOptions                  | IRestOptions    | Contact support for usage instructions.                                                                                                                                       |
+| configPollingIntervalMS      | int             | Controls the polling interval in milliseconds to fetch new environment config changes, defaults to 30 seconds, minimum value is 1 second.                                     |
+| configPollingTimeoutMs       | int             | Controls the request timeout to fetch new environment config changes, defaults to 10 seconds, must be less than the configPollingIntervalMS value, minimum value is 1 second. |
+| eventFlushIntervalMS         | int             | Controls the interval between flushing events to the DevCycle servers, defaults to 10 seconds.                                                                                |
+| flushEventQueueSize          | int             | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                            |
+| maxEventQueueSize            | int             | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                                           |
+| eventRequestChunkSize        | int             | Count of events to chunk per event upload request. Defaults to `100`.                                                                                                         |
+| disableAutomaticEventLogging | boolean         | Disables logging of sdk generated events (e.g. aggVariableEvaluated, aggVariableDefaulted) to DevCycle.                                                                       |
+| disableCustomEventLogging    | boolean         | Disables logging of custom events, from `track()` method, and user data to DevCycle.                                                                                          |
+| configCdnBaseUrl             | String          | Contact support for usage instructions.                                                                                                                                       |
+| eventsApiBaseUrl             | String          | Contact support for usage instructions.                                                                                                                                       |
+| disableRealtimeUpdates       | boolean         | Disables the usage of realtime updates SSE connections for DevCycle, will revert to polling against the config CDN.                                                           |
 
 ### Cloud Bucketing Options
 
-| DevCycle Option              | Type           | Description                                                                                                                                                                  |
-|------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| customLogger                       | IDevCycleLogger | Logger override to replace default logger                                                                                                                                    |
-| restOptions                       | IRestOptions | Contact support for usage instructions                                                                                                                                    |
-| enableEdgeDB                 | Boolean        | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. <br />NOTE: This is only available with Cloud Bucketing enabled.                                          |
-| baseUrlOverride                  | String         | Contact support for usage instructions.                                                                                       |
+| DevCycle Option | Type            | Description                                                                                                                                 |
+| --------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| customLogger    | IDevCycleLogger | Logger override to replace default logger                                                                                                   |
+| restOptions     | IRestOptions    | Contact support for usage instructions                                                                                                      |
+| enableEdgeDB    | Boolean         | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. <br />NOTE: This is only available with Cloud Bucketing enabled. |
+| baseUrlOverride | String          | Contact support for usage instructions.                                                                                                     |

--- a/docs/sdk/server-side-sdks/java/java-usage.md
+++ b/docs/sdk/server-side-sdks/java/java-usage.md
@@ -187,29 +187,22 @@ In the example, Email and Country are associated to the user `test_user`.
 In your next identify call for the same `userId`, you may omit any of the data you've sent already as it will be pulled
 from the EdgeDB storage when segmenting to experiments and features.
 
+## Realtime Updates
 
-## Enabling Beta Realtime Updates
-:::warning
-This feature is in beta, and may not function as expected. Please ensure that you have the latest version of the SDK.
-:::
-
-This functionality will reduce the number of polling requests that are made to the DevCycle Config CDN, and instead will
+This feature reduces the number of polling requests that are made to the DevCycle Config CDN, and instead will
 use a long-lived HTTP connection (Server Sent Events) to receive updates when there is a new config available.
 This reduces outbound network traffic, as well as optimizes the SDK for efficiency.
 
-To enable Beta Realtime Updates, pass in the `enableBetaRealtimeUpdates` option to the SDK initialization:
+To disable realtime updates, pass in the `disableRealtimeUpdates` option to the SDK initialization:
 
 ```java
-import com.devcycle.sdk.server.local.api.DevCycleLocalClient;
-import com.devcycle.sdk.server.local.model.DevCycleLocalOptions;
-
 public class MyClass {
 
     private DevCycleLocalClient client;
 
     public MyClass() {
         DevCycleLocalOptions options = DevCycleLocalOptions.builder()
-            .enableBetaRealtimeUpdates(true)
+            .disableRealtimeUpdates(true)
             .build();
 
         client = new DevCycleLocalClient(System.getenv("DEVCYCLE_SERVER_SDK_KEY"), options);

--- a/docs/sdk/server-side-sdks/nestjs/nestjs-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/nestjs/nestjs-gettingstarted.md
@@ -9,7 +9,7 @@ sidebar_custom_props: { icon: material-symbols:rocket }
 [![Npm package version](https://badgen.net/npm/v/@devcycle/nestjs-server-sdk)](https://www.npmjs.com/package/@devcycle/nestjs-server-sdk)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/js-sdks.svg?style=social&label=Star&maxAge=2592000)](https://github.com/devcyclehq/js-sdks)
 
-[//]: # (wizard-initialize-start)
+[//]: # 'wizard-initialize-start'
 
 To use the DevCycle Server SDK in your project, import the `DevCycleModule` from the `@devcycle/nestjs-server-sdk`.
 We recommend adding the module to the imports of your root app module, so that the DevCycle client is available globally within your application.
@@ -20,7 +20,7 @@ Example:
 import { DevCycleModule } from '@devcycle/nestjs-server-sdk'
 
 DevCycleModule.forRoot({
-  key: '<DEVCYCLE_SERVER_SDK_KEY>'
+  key: '<DEVCYCLE_SERVER_SDK_KEY>',
 })
 ```
 
@@ -58,10 +58,11 @@ DevCycleModule.forRoot({
       user_id: req.user.id,
       email: req.user.email,
     }
-  }
+  },
 })
 ```
-[//]: # (wizard-initialize-end)
+
+[//]: # 'wizard-initialize-end'
 
 ## Initialization Options
 
@@ -74,12 +75,12 @@ DevCycleModule.forRoot({
   key: '<DEVCYCLE_SERVER_SDK_KEY>',
   options: {
     // Insert Options
-    }
+  },
 })
 ```
 
 | DevCycle Option              | Type           | Description                                                                                                                                                                  |
-|------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | logger                       | DevCycleLogger | Logger override to replace default logger                                                                                                                                    |
 | logLevel                     | String         | Set log level of the default logger. Options are: `debug`, `info`, `warn`, `error`. Defaults to `info`.                                                                      |
 | enableCloudBucketing         | Boolean        | Switches the SDK to use Cloud Bucketing (via the DevCycle Bucketing API) instead of Local Bucketing.                                                                         |
@@ -92,4 +93,4 @@ DevCycleModule.forRoot({
 | flushEventQueueSize          | Number         | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                           |
 | maxEventQueueSize            | Number         | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                                          |
 | apiProxyURL                  | String         | Allows the SDK to communicate with a proxy of DevCycle bucketing API / client SDK API.                                                                                       |
-| enableBetaRealtimeUpdates    | Boolean        | Enables the usage of Beta Realtime Updates for DevCycle. This feature is currently in beta.                                                                                  |
+| disableRealtimeUpdates       | Boolean        | Disables the usage of realtime updates SSE connections for DevCycle, will revert to polling against the config CDN.                                                          |

--- a/docs/sdk/server-side-sdks/nestjs/nestjs-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/nestjs/nestjs-gettingstarted.md
@@ -9,7 +9,7 @@ sidebar_custom_props: { icon: material-symbols:rocket }
 [![Npm package version](https://badgen.net/npm/v/@devcycle/nestjs-server-sdk)](https://www.npmjs.com/package/@devcycle/nestjs-server-sdk)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/js-sdks.svg?style=social&label=Star&maxAge=2592000)](https://github.com/devcyclehq/js-sdks)
 
-[//]: # 'wizard-initialize-start'
+[//]: # (wizard-initialize-start)
 
 To use the DevCycle Server SDK in your project, import the `DevCycleModule` from the `@devcycle/nestjs-server-sdk`.
 We recommend adding the module to the imports of your root app module, so that the DevCycle client is available globally within your application.
@@ -62,7 +62,7 @@ DevCycleModule.forRoot({
 })
 ```
 
-[//]: # 'wizard-initialize-end'
+[//]: # (wizard-initialize-end)
 
 ## Initialization Options
 

--- a/docs/sdk/server-side-sdks/nestjs/nestjs-usage.md
+++ b/docs/sdk/server-side-sdks/nestjs/nestjs-usage.md
@@ -10,7 +10,8 @@ sidebar_custom_props: { icon: material-symbols:toggle-on }
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/js-sdks.svg?style=social&label=Star&maxAge=2592000)](https://github.com/devcyclehq/js-sdks)
 
 ## DevCycle Client
-[//]: # (wizard-evaluate-start)
+
+[//]: # 'wizard-evaluate-start'
 
 With the DevCycleModule imported, the `DevCycleClient` can be injected into your controllers or providers.
 
@@ -20,34 +21,32 @@ The Nest.js SDK is a wrapper for DevCycle's Node.js SDK. For more information ab
 import { DevCycleClient } from '@devcycle/nestjs-server-sdk'
 
 export class MyController {
-    constructor(
-      private readonly devcycleClient: DevCycleClient
-    ) {}
+  constructor(private readonly devcycleClient: DevCycleClient) {}
 
-    async update() {
-      const user = {
-        user_id: 'user1@devcycle.com',
-        name: 'user 1 name',
-        customData: {
-          customKey: 'customValue',
-        },
-      }
-      const variable = this.devcycleClient.variable(user, 'test-variable', false)
+  async update() {
+    const user = {
+      user_id: 'user1@devcycle.com',
+      name: 'user 1 name',
+      customData: {
+        customKey: 'customValue',
+      },
     }
+    const variable = this.devcycleClient.variable(user, 'test-variable', false)
+  }
 }
 ```
-[//]: # (wizard-evaluate-end)
+
+[//]: # 'wizard-evaluate-end'
 
 ## DevCycle Service
+
 With the DevCycleModule imported, the `DevCycleService` can be injected into your controllers or providers. The DevCycleService methods evaluate variables with the user returned from your [userFactory](/sdk/server-side-sdks/nestjs/nestjs-gettingstarted#user-factory), so you don't need to specify a user each time a method is called.
 
 ```typescript
 import { DevCycleService } from '@devcycle/nestjs-server-sdk'
 
 export class MyService {
-  constructor(
-    private readonly devcycleService: DevCycleService,
-  ) {}
+  constructor(private readonly devcycleService: DevCycleService) {}
 
   async update() {
     const enabled = this.devcycleService.isEnabled('allow-feature-edits')
@@ -59,6 +58,7 @@ export class MyService {
 ```
 
 ### variableValue
+
 The `variableValue` method accepts a variable key and default value, and returns the served value.
 
 ```typescript
@@ -66,6 +66,7 @@ const value = this.devcycleService.variableValue('variable-key', 'hello world')
 ```
 
 ### isEnabled
+
 The `isEnabled` method accepts a key for a boolean variable. The default value is always `false` when using the `isEnabled` method.
 
 ```typescript
@@ -73,6 +74,7 @@ const enabled = this.devcycleService.isEnabled('boolean-variable')
 ```
 
 ### getUser
+
 The `getUser` method returns the user object from your [userFactory](/sdk/server-side-sdks/nestjs/nestjs-gettingstarted#user-factory).
 
 ```typescript
@@ -84,6 +86,7 @@ const devcycleUser = this.devcycleService.getUser()
 DevCycle decorators evaluate variables with the user returned from your [userFactory](/sdk/server-side-sdks/nestjs/nestjs-gettingstarted#user-factory), so you don't need to specify a user each time a decorator is used.
 
 ### VariableValue
+
 The `VariableValue` decorator can be used to access variable values directly in your route handlers.
 
 ```typescript
@@ -97,6 +100,7 @@ async findAll(
 ```
 
 ### RequireVariableValue
+
 The `RequireVariableValue` decorator can be used to guard an endpoint or controller.
 If the user is not served the specified value, the request will return a 404 NotFound as though the endpoint does not exist.
 
@@ -109,24 +113,21 @@ async findAll() {
 }
 ```
 
-## Enabling Beta Realtime Updates
-:::warning
-This feature is in beta, and may not function as expected. Please ensure that you have the latest version of the SDK.
-:::
+## Realtime Updates
 
-This functionality will reduce the number of polling requests that are made to the DevCycle Config CDN, and instead will
+This feature reduces the number of polling requests that are made to the DevCycle Config CDN, and instead will
 use a long-lived HTTP connection (Server Sent Events) to receive updates when there is a new config available.
 This reduces outbound network traffic, as well as optimizes the SDK for efficiency.
 
-To enable Beta Realtime Updates, pass in the `enableBetaRealtimeUpdates` option to the SDK initialization:
+To disable realtime updates, pass in the `disableRealtimeUpdates` option to the SDK initialization:
 
-```javascript
+```typescript
 import { DevCycleModule } from '@devcycle/nestjs-server-sdk'
 
 DevCycleModule.forRoot({
   key: '<DEVCYCLE_SERVER_SDK_KEY>',
   options: {
-    enableBetaRealtimeUpdates: true
-  }
+    disableRealtimeUpdates: true,
+  },
 })
 ```

--- a/docs/sdk/server-side-sdks/nestjs/nestjs-usage.md
+++ b/docs/sdk/server-side-sdks/nestjs/nestjs-usage.md
@@ -11,7 +11,7 @@ sidebar_custom_props: { icon: material-symbols:toggle-on }
 
 ## DevCycle Client
 
-[//]: # 'wizard-evaluate-start'
+[//]: # (wizard-evaluate-start)
 
 With the DevCycleModule imported, the `DevCycleClient` can be injected into your controllers or providers.
 
@@ -36,7 +36,7 @@ export class MyController {
 }
 ```
 
-[//]: # 'wizard-evaluate-end'
+[//]: # (wizard-evaluate-end)
 
 ## DevCycle Service
 

--- a/docs/sdk/server-side-sdks/node/node-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/node/node-gettingstarted.md
@@ -52,7 +52,7 @@ const devcycleClient = await DevCycle.initializeDevCycle(
 ```
 
 | DevCycle Option              | Type           | Description                                                                                                                                                                  |
-|------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | logger                       | DevCycleLogger | Logger override to replace default logger                                                                                                                                    |
 | logLevel                     | String         | Set log level of the default logger. Options are: `debug`, `info`, `warn`, `error`. Defaults to `info`.                                                                      |
 | enableCloudBucketing         | Boolean        | Switches the SDK to use Cloud Bucketing (via the DevCycle Bucketing API) instead of Local Bucketing.                                                                         |
@@ -65,4 +65,4 @@ const devcycleClient = await DevCycle.initializeDevCycle(
 | flushEventQueueSize          | Number         | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                           |
 | maxEventQueueSize            | Number         | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                                          |
 | apiProxyURL                  | String         | Allows the SDK to communicate with a proxy of DevCycle bucketing API / client SDK API.                                                                                       |
-| enableBetaRealtimeUpdates    | Boolean        | Enables the usage of Beta Realtime Updates for DevCycle. This feature is currently in beta.                                                                                  |
+| disableRealtimeUpdates       | Boolean        | Disables the usage of realtime updates SSE connections for DevCycle, will revert to polling against the config CDN.                                                          |

--- a/docs/sdk/server-side-sdks/node/node-usage.md
+++ b/docs/sdk/server-side-sdks/node/node-usage.md
@@ -142,28 +142,24 @@ This will send a request to our EdgeDB API to save the custom data under the use
 
 In the example, Email and Country are associated to the user `test_user`. In your next variable call for the same `user_id`, you may omit any of the data you've sent already as it will be pulled from the EdgeDB storage when segmenting to experiments and features.
 
-## Enabling Beta Realtime Updates
-:::warning
-This feature is in beta, and may not function as expected. Please ensure that you have the latest version of the SDK.
-:::
+## Realtime Updates
 
-This functionality will reduce the number of polling requests that are made to the DevCycle Config CDN, and instead will
+This feature reduces the number of polling requests that are made to the DevCycle Config CDN, and instead will
 use a long-lived HTTP connection (Server Sent Events) to receive updates when there is a new config available.
 This reduces outbound network traffic, as well as optimizes the SDK for efficiency.
 
-To enable Beta Realtime Updates, pass in the `enableBetaRealtimeUpdates` option to the SDK initialization:
-```javascript
+To disable realtime updates, pass in the `disableRealtimeUpdates` option to the SDK initialization:
+
+```typescript
 const devcycleClient = DevCycle.initializeDevCycle(
   '<DEVCYCLE_SERVER_SDK_KEY>',
   {
-    enableBetaRealtimeUpdates: true,
+    disableRealtimeUpdates: true,
   },
 )
 ```
-
 
 ## Close Client
 
 If you need to close the DevCycleClient object to stop all open connections and timers, call `devcycleClient.close()`.
 This can be useful for cleaning DevCycleClient objects during unit testing.
-

--- a/docs/sdk/server-side-sdks/python/python-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/python/python-gettingstarted.md
@@ -77,31 +77,30 @@ devcycle_client = DevCycleLocalClient(os.environ["DEVCYCLE_SERVER_SDK_KEY"], opt
 
 ### Local Bucketing Options
 
-| DevCycle Option              | Type           | Description                                                                                                                                                                  |
-|------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| config_cdn_uri      | str         | Contact support for usage instructions.                                    |
-| config_request_timeout_ms       | int         | Controls the request timeout to fetch new environment config changes, defaults to 5 seconds, must be less than the configPollingIntervalMS value, minimum value is 1 second. |
-| config_polling_interval_ms      | int         | Controls the polling interval in milliseconds to fetch new environment config changes, defaults to 1 second.                                    |
-| config_retry_delay_ms      | int         | Controls the delay between retries to fetch new environment config changes, defaults to 200 milliseconds.                                    |
-| on_client_initialized      | Optional[Callable]         | Contact DevCycle support for instructions on how to configure this option.                                    |
-| events_api_uri      | str         | Contact support for usage instructions.                                    |
-| max_event_queue_size            | int         | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                 |
-| event_flush_interval_ms         | int         | Controls the interval between flushing events to the DevCycle servers, defaults to 10 seconds.                                               |
-| flush_event_queue_size          | int         | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                           |
-| event_request_chunk_size          | int         | Count of events to chunk per event upload request. Defaults to `100`.                                                                           |
-| event_request_timeout_ms         | int         | Controls the request timeout for posting events to DevCycle. Defaults to `10000`.                                                              |
-| event_retry_delay_ms          | int         | Controls the delay between retries when posting events to DevCycle. Defaults to `100`.                                                                           |
-| disable_automatic_event_logging | bool        | Disables logging of sdk generated events (e.g. aggVariableEvaluated, aggVariableDefaulted) to DevCycle.                                                                      |
-| disable_custom_event_logging    | bool        | Disables logging of custom events, from `track()` method, and user data to DevCycle.                                                                                         |
-| enable_beta_realtime_ypdates    | bool        | Enables the usage of Beta Realtime Updates for DevCycle. This feature is currently in beta.                                                                                  |
-
+| DevCycle Option                 | Type               | Description                                                                                                                                                                  |
+| ------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| config_cdn_uri                  | str                | Contact support for usage instructions.                                                                                                                                      |
+| config_request_timeout_ms       | int                | Controls the request timeout to fetch new environment config changes, defaults to 5 seconds, must be less than the configPollingIntervalMS value, minimum value is 1 second. |
+| config_polling_interval_ms      | int                | Controls the polling interval in milliseconds to fetch new environment config changes, defaults to 1 second.                                                                 |
+| config_retry_delay_ms           | int                | Controls the delay between retries to fetch new environment config changes, defaults to 200 milliseconds.                                                                    |
+| on_client_initialized           | Optional[Callable] | Contact DevCycle support for instructions on how to configure this option.                                                                                                   |
+| events_api_uri                  | str                | Contact support for usage instructions.                                                                                                                                      |
+| max_event_queue_size            | int                | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                                          |
+| event_flush_interval_ms         | int                | Controls the interval between flushing events to the DevCycle servers, defaults to 10 seconds.                                                                               |
+| flush_event_queue_size          | int                | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                           |
+| event_request_chunk_size        | int                | Count of events to chunk per event upload request. Defaults to `100`.                                                                                                        |
+| event_request_timeout_ms        | int                | Controls the request timeout for posting events to DevCycle. Defaults to `10000`.                                                                                            |
+| event_retry_delay_ms            | int                | Controls the delay between retries when posting events to DevCycle. Defaults to `100`.                                                                                       |
+| disable_automatic_event_logging | bool               | Disables logging of sdk generated events (e.g. aggVariableEvaluated, aggVariableDefaulted) to DevCycle.                                                                      |
+| disable_custom_event_logging    | bool               | Disables logging of custom events, from `track()` method, and user data to DevCycle.                                                                                         |
+| disable_realtime_updates        | bool               | Disables the usage of realtime updates SSE connections for DevCycle, will revert to polling against the config CDN.                                                          |
 
 ### Cloud Bucketing Options
 
-| DevCycle Option              | Type           | Description                                                                                                                                                                  |
-|------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| enable_edge_db                 | bool        | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle.                                          |
-| bucketing_api_uri             | str        | Contact support for usage instructions.                                          |
-| request_timeout       | int         | Controls the request timeout to fetch new environment config changes, defaults to 5 seconds, minimum value is 1 second. |
-| request_retries         | int         | Controls the number of request retries to the DevCycle servers, defaults to 5.                                                                               |
-| retry_delay         | int         | Controls the delay between retries to the DevCycle servers, defaults to 200 milliseconds.                                                                               |
+| DevCycle Option   | Type | Description                                                                                                             |
+| ----------------- | ---- | ----------------------------------------------------------------------------------------------------------------------- |
+| enable_edge_db    | bool | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle.                                              |
+| bucketing_api_uri | str  | Contact support for usage instructions.                                                                                 |
+| request_timeout   | int  | Controls the request timeout to fetch new environment config changes, defaults to 5 seconds, minimum value is 1 second. |
+| request_retries   | int  | Controls the number of request retries to the DevCycle servers, defaults to 5.                                          |
+| retry_delay       | int  | Controls the delay between retries to the DevCycle servers, defaults to 200 milliseconds.                               |

--- a/docs/sdk/server-side-sdks/python/python-usage.md
+++ b/docs/sdk/server-side-sdks/python/python-usage.md
@@ -172,25 +172,16 @@ or the SDK is not able to make requests to the DevCycle API directly. The instal
 
 See the [SDK Proxy](../../sdk-proxy/index.md) section for more information.
 
-## Enabling Beta Realtime Updates
-:::warning
-This feature is in beta, and may not function as expected. Please ensure that you have the latest version of the SDK.
-:::
+## Realtime Updates
 
-This functionality will reduce the number of polling requests that are made to the DevCycle Config CDN, and instead will
+This feature reduces the number of polling requests that are made to the DevCycle Config CDN, and instead will
 use a long-lived HTTP connection (Server Sent Events) to receive updates when there is a new config available.
 This reduces outbound network traffic, as well as optimizes the SDK for efficiency.
 
-To enable Beta Realtime Updates, pass in the `enable_beta_realtime_updates` option to the SDK initialization:
+To disable realtime updates, pass in the `disable_realtime_updates` option to the SDK initialization:
 
 ```python
-from devcycle_python_sdk import DevCycleLocalClient, DevCycleLocalOptions
-from devcycle_python_sdk.models.user import DevCycleUser
-import os
+options = DevCycleLocalOptions(disable_realtime_updates=True)
 
-# Create an options object to do custom configurations, or use the defaults
-options = DevCycleLocalOptions(enable_beta_realtime_updates=True)
-
-# create an instance of the DevCycleLocalClient class
 devcycle_client = DevCycleLocalClient(os.environ["DEVCYCLE_SERVER_SDK_KEY"], options)
 ```

--- a/docs/sdk/server-side-sdks/ruby/ruby-gettingstarted.md
+++ b/docs/sdk/server-side-sdks/ruby/ruby-gettingstarted.md
@@ -98,28 +98,19 @@ user = DevCycle::User.new({
  })
 ```
 
-| DevCycle Option              | Type           | Description                                                                                                                                                                  |
-|------------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| enable_cloud_bucketing         | Boolean        | Switches the SDK to use Cloud Bucketing (via the DevCycle Bucketing API) instead of Local Bucketing.                                                                         |
-| event_flush_interval_ms         | Int         | Controls the interval between flushing events to the DevCycle servers, defaults to 30 seconds.                                                                               |
+| DevCycle Option                 | Type           | Description                                                                                                                                                                  |
+| ------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| enable_cloud_bucketing          | Boolean        | Switches the SDK to use Cloud Bucketing (via the DevCycle Bucketing API) instead of Local Bucketing.                                                                         |
+| event_flush_interval_ms         | Int            | Controls the interval between flushing events to the DevCycle servers, defaults to 30 seconds.                                                                               |
 | disable_custom_event_logging    | Boolean        | Disables logging of custom events, from `track()` method, and user data to DevCycle.                                                                                         |
 | disable_automatic_event_logging | Boolean        | Disables logging of sdk generated events (e.g. aggVariableEvaluated, aggVariableDefaulted) to DevCycle.                                                                      |
-| config_polling_interval_ms      | Int         | Controls the polling interval in milliseconds to fetch new environment config changes, defaults to 10 seconds, minimum value is 1 second.                                    |
-| enable_beta_realtime_updates    | Boolean        | Enables the usage of Beta Realtime Updates for DevCycle. This feature is currently in beta.                                                                                  |
-| request_timeout_ms       | Int         | Controls the request timeout to fetch new environment config changes, defaults to 5 seconds, must be less than the configPollingIntervalMS value, minimum value is 1 second. |
-| max_event_queue_size            | Int         | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                                          |
-| flush_event_queue_size          | Int         | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                           |
-| event_request_chunk_size          | Int         | Count of events to chunk per event upload request. Defaults to `100`.                                                                           |
-| logger                       | DevCycleLogger | Logger override to replace default logger                                                                                                                                    |
-| config_cdn_uri                  | String         | Contact support for usage instructions.                                                                                       |
-| events_api_uri                  | String         | Contact support for usage instructions.                                                                                       |
-| enable_edge_db                 | Boolean        | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. <br />NOTE: This is only available with Cloud Bucketing.                                          |
-
-
-
-
-
-
-
-
-
+| config_polling_interval_ms      | Int            | Controls the polling interval in milliseconds to fetch new environment config changes, defaults to 10 seconds, minimum value is 1 second.                                    |
+| disable_realtime_updates        | Boolean        | Disables the usage of realtime updates SSE connections for DevCycle, will revert to polling against the config CDN.                                                          |
+| request_timeout_ms              | Int            | Controls the request timeout to fetch new environment config changes, defaults to 5 seconds, must be less than the configPollingIntervalMS value, minimum value is 1 second. |
+| max_event_queue_size            | Int            | Controls the maximum size the event queue can grow to until events are dropped. Defaults to `2000`.                                                                          |
+| flush_event_queue_size          | Int            | Controls the maximum size the event queue can grow to until a flush is forced. Defaults to `1000`.                                                                           |
+| event_request_chunk_size        | Int            | Count of events to chunk per event upload request. Defaults to `100`.                                                                                                        |
+| logger                          | DevCycleLogger | Logger override to replace default logger                                                                                                                                    |
+| config_cdn_uri                  | String         | Contact support for usage instructions.                                                                                                                                      |
+| events_api_uri                  | String         | Contact support for usage instructions.                                                                                                                                      |
+| enable_edge_db                  | Boolean        | Enables the usage of EdgeDB for DevCycle that syncs User Data to DevCycle. <br />NOTE: This is only available with Cloud Bucketing.                                          |

--- a/docs/sdk/server-side-sdks/ruby/ruby-usage.md
+++ b/docs/sdk/server-side-sdks/ruby/ruby-usage.md
@@ -164,23 +164,18 @@ In the example, Email and Country are associated to the user `test_user`.
 In your next identify call for the same `user_id`, you may omit any of the data you've sent already as it will be pulled
 from the EdgeDB storage when segmenting to experiments and features.
 
-## Enabling Beta Realtime Updates
-:::warning
-This feature is in beta, and may not function as expected. Please ensure that you have the latest version of the SDK.
-:::
+## Realtime Updates
 
-This functionality will reduce the number of polling requests that are made to the DevCycle Config CDN, and instead will
+This feature reduces the number of polling requests that are made to the DevCycle Config CDN, and instead will
 use a long-lived HTTP connection (Server Sent Events) to receive updates when there is a new config available.
 This reduces outbound network traffic, as well as optimizes the SDK for efficiency.
 
-To enable Beta Realtime Updates, pass in the `enableBetaRealtimeUpdates` option to the SDK initialization:
+To disable realtime updates, pass in the `disable_realtime_updates` option to the SDK initialization:
 
 ```ruby
-# Load the gem
 require 'devcycle-ruby-server-sdk'
 
-# Setup authorization
-options = DevCycle::Options.new(enableBetaRealtimeUpdates: true)
+options = DevCycle::Options.new(disable_realtime_updates: true)
 
 devcycle_client = DevCycle::Client.new("dvc_server_token_hash", options, true)
 user = DevCycle::User.new({
@@ -188,3 +183,4 @@ user = DevCycle::User.new({
    email: 'example@example.ca',
    country: 'CA'
  })
+```


### PR DESCRIPTION
Update realtime update docs now that SDKs default to it enabled

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
