### PR TITLE
Fix pagination on overview page

### DIFF
--- a/docs/essentials/key-features.md
+++ b/docs/essentials/key-features.md
@@ -1,4 +1,5 @@
 ---
+id: key-features
 title: Key Features
 sidebar_position: 2
 ---

--- a/docs/essentials/overview.md
+++ b/docs/essentials/overview.md
@@ -1,6 +1,7 @@
 ---
 title: DevCycle Overview
 sidebar_position: 1
+pagination_next: essentials/key-features
 ---
 
 DevCycle is a feature flag platform built for engineering teams of any size, helping you easily create, rollout, and cleanup feature flags without disrupting your workflow.


### PR DESCRIPTION
Overview page now points to Key Features instead of itself