### PR TITLE
Add Ruby Example App to docs

### DIFF
--- a/docs/integrations/openfeature.mdx
+++ b/docs/integrations/openfeature.mdx
@@ -85,6 +85,13 @@ import CustomDocCardList from '@site/src/components/CustomDocCardList'
       description: 'hidden',
       icon: 'simple-icons:php',
     },
+    {
+      type: 'link',
+      href: '/sdk/server-side-sdks/ruby/ruby-openfeature',
+      label: 'Ruby',
+      description: 'hidden',
+      icon: 'simple-icons:ruby',
+    },
   ]}
 />
 

--- a/docs/integrations/openfeature.mdx
+++ b/docs/integrations/openfeature.mdx
@@ -46,7 +46,7 @@ import CustomDocCardList from '@site/src/components/CustomDocCardList'
     {
       type: 'link',
       href: '/sdk/server-side-sdks/node/node-openfeature',
-      label: 'NodeJS',
+      label: 'Node.js',
       description: 'hidden',
       icon: 'simple-icons:nodedotjs',
     },
@@ -91,6 +91,13 @@ import CustomDocCardList from '@site/src/components/CustomDocCardList'
       label: 'Ruby',
       description: 'hidden',
       icon: 'simple-icons:ruby',
+    },
+    {
+      type: 'link',
+      href: '/sdk/server-side-sdks/nestjs/nestjs-openfeature',
+      label: 'NestJS',
+      description: 'hidden',
+      icon: 'simple-icons:nestjs',
     },
   ]}
 />

--- a/docs/sdk/server-side-sdks/ruby/ruby-example.mdx
+++ b/docs/sdk/server-side-sdks/ruby/ruby-example.mdx
@@ -27,5 +27,12 @@ import CustomDocCardList from '@site/src/components/CustomDocCardList'
       description: 'hidden',
       icon: 'simple-icons:ruby',
     },
+    {
+      type: 'link',
+      href: 'https://github.com/DevCycleHQ-Labs/example-openfeature-ruby',
+      label: 'OpenFeature App',
+      description: 'hidden',
+      icon: 'material-symbols:toggle-on',
+    },
   ]}
 />


### PR DESCRIPTION
Contains the following changes:
- Add the Ruby OpenFeature example app to the example apps section
- Add the Ruby OpenFeature SDK to the list of SDKs on the OpenFeature page