### PR TITLE
chore: Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,5 +1,8 @@
 name: Check Markdown links
 
+permissions:
+  contents: read
+
 on: 
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/devcycle-docs/security/code-scanning/2](https://github.com/DevCycleHQ/devcycle-docs/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify `contents: read`, which is the minimum required permission for the workflow to read the repository contents and check Markdown links. This change ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
