### PR TITLE
chore: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -3,6 +3,8 @@ on:
     - cron: 0 0 1 * * # run monthly
   workflow_dispatch:
 name: Broken Link Check
+permissions:
+  contents: read
 jobs:
   check:
     name: Broken Link Check


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/devcycle-docs/security/code-scanning/1](https://github.com/DevCycleHQ/devcycle-docs/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow is performing a broken link check, it likely only requires `contents: read` permissions. This block should be added at the root level of the workflow to apply to all jobs, as there is only one job in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
