### PR TITLE
docs: add android openfeature docs

### DIFF
--- a/docs/sdk/client-side-sdks/android/android-openfeature.md
+++ b/docs/sdk/client-side-sdks/android/android-openfeature.md
@@ -219,7 +219,7 @@ val userContext = ImmutableContext(
 
 DevCycle only supports flat JSON Object properties used in the Context. Non-flat properties will be ignored.
 
-For example `obj` will be ignored:
+For example `obj` will be ignored in the following structure:
 
 ```kotlin
 val newContext = ImmutableContext(


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
