### PR TITLE
chore: update docs with variable evaluation usage

### DIFF
--- a/docs/sdk/server-side-sdks/go/go-usage.md
+++ b/docs/sdk/server-side-sdks/go/go-usage.md
@@ -8,7 +8,7 @@ sidebar_custom_props: { icon: material-symbols:toggle-on }
 
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/go-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/go-server-sdk)
 
-[//]: # (wizard-evaluate-start)
+[//]: # 'wizard-evaluate-start'
 
 ## User Object
 
@@ -29,6 +29,7 @@ Any number types passed into `customData`, `privateCustomData` or `ClientCustomD
 to avoid any potential issues with floating point error.
 
 :::
+
 ## Get and Use Variable by Key
 
 This method will fetch a specific variable value by key for a given user. It will return the variable
@@ -37,7 +38,8 @@ value unless an error occurs. In that case it will return a variable value set t
 ```go
 variableValue, err := devcycleClient.VariableValue(user, "my-variable-key", "test")
 ```
-[//]: # (wizard-evaluate-end)
+
+[//]: # 'wizard-evaluate-end'
 
 `variableValue` is an `interface{}` - so you'll need to cast it to your proper variable type.
 When using `JSON` as the variable type, you'll have to have JSON to unmarshal it to a proper type instead of accessing it raw.
@@ -87,7 +89,7 @@ variables, err := devcycleClient.AllVariables(user)
 
 :::caution
 
-This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+This method is intended to be used for debugging and analytics purposes, _not_ as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
 Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
 of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
@@ -173,4 +175,46 @@ options := devcycle.Options{
 }
 
 devcycleClient, err := devcycle.NewClient(sdkKey, &options)
+```
+
+## Evaluation Hooks
+
+Using evaluation hooks, you can hook into the lifecycle of a variable evaluation to execute code before and after execution of the evaluation.
+
+**Note**: Each evaluation will wait for all hooks before returning the variable evaluation, which depending on the complexity of the hooks will cause slower function call times. This also may lead to blocking variable evaluations in the future until all hooks return depending on the volume of calls to `.variable`.
+
+> [!WARNING]
+> Do not call any variable evaluation functions (.variable/variableValue) in any of the hooks, as it may cause infinite recursion.
+
+To add a hook:
+
+```go
+before := func(context *HookContext) error {
+    // before hook
+    return nil
+}
+
+after := func(context *HookContext, variable *api.Variable) error {
+    // after hook
+    return nil
+}
+
+onFinally := func(context *HookContext, variable *api.Variable) error {
+    // onFinally hook
+    return nil
+}
+
+error := func(context *HookContext, evalError error) error {
+    // error hook
+    return nil
+}
+
+evalHook := NewEvalHook(before, after, onFinally, error)
+client.AddHook(evalHook)
+```
+
+You can also clear the hooks:
+
+```go
+client.ClearHooks()
 ```

--- a/docs/sdk/server-side-sdks/java/java-usage.md
+++ b/docs/sdk/server-side-sdks/java/java-usage.md
@@ -9,7 +9,7 @@ sidebar_custom_props: { icon: material-symbols:toggle-on }
 [![Maven](https://badgen.net/maven/v/maven-central/com.devcycle/java-server-sdk)](https://search.maven.org/artifact/com.devcycle/java-server-sdk)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/java-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/java-server-sdk)
 
-[//]: # (wizard-evaluate-start)
+[//]: # 'wizard-evaluate-start'
 
 ## DevCycleUser Object
 
@@ -40,7 +40,8 @@ if (variableValue.booleanValue()) {
     // Old code here
 }
 ```
-[//]: # (wizard-evaluate-end)
+
+[//]: # 'wizard-evaluate-end'
 
 The default value can be of type `String`, `Boolean`, `Number`, or `Object`.
 
@@ -48,7 +49,8 @@ If you would like to get the full Variable Object you can use `variable()` inste
 `key`, `value`, `type`, `defaultValue`, `isDefaulted`.
 
 ## Getting All Variables
-This method will fetch all variables for a given user and return as Map&lt;String, Variable&gt;. 
+
+This method will fetch all variables for a given user and return as Map&lt;String, Variable&gt;.
 If the project configuration is unavailable, this will return an empty map.
 
 To get values from your Variables, the `value` field inside the variable object can be accessed.
@@ -58,14 +60,16 @@ import com.devcycle.sdk.server.common.model.BaseVariable;
 
 Map<String, BaseVariable> variables = client.allVariables(user);
 ```
+
 :::caution
 
-This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+This method is intended to be used for debugging and analytics purposes, _not_ as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
 Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
 of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
 
 :::
+
 ## Getting All Features
 
 This method will fetch all features for a given user and return them as Map&lt;String, Feature&gt;.
@@ -208,4 +212,45 @@ public class MyClass {
         client = new DevCycleLocalClient(System.getenv("DEVCYCLE_SERVER_SDK_KEY"), options);
     }
 }
+```
+
+## Evaluation Hooks
+
+Using evaluation hooks, you can hook into the lifecycle of a variable evaluation to execute code before and after execution of the evaluation.
+
+**Note**: Each evaluation will wait for all hooks before returning the variable evaluation, which depending on the complexity of the hooks will cause slower function call times. This also may lead to blocking variable evaluations in the future until all hooks return depending on the volume of calls to `.variable`.
+
+> [!WARNING]
+> Do not call any variable evaluation functions (.variable/variableValue) in any of the hooks, as it may cause infinite recursion.
+
+To add a hook:
+
+```java
+client.addHook(new EvalHook<String>() {
+    @Override
+    public Optional<HookContext<String>> before(HookContext<String> ctx) {
+        // before hook
+    }
+
+    @Override
+    public void after(HookContext<String> ctx, Variable<String> variable) {
+        // after hook
+    }
+
+    @Override
+    public void error(HookContext<String> ctx, Throwable error) {
+        // error hook
+    }
+
+    @Override
+    public void onFinally(HookContext<String> ctx, Optional<Variable<String>> variable) {
+        // finally hook
+    }
+});
+```
+
+You can also clear the hooks:
+
+```
+client.clearHooks()
 ```

--- a/docs/sdk/server-side-sdks/node/node-usage.md
+++ b/docs/sdk/server-side-sdks/node/node-usage.md
@@ -9,7 +9,7 @@ sidebar_custom_props: { icon: material-symbols:toggle-on }
 [![Npm package version](https://badgen.net/npm/v/@devcycle/nodejs-server-sdk)](https://www.npmjs.com/package/@devcycle/nodejs-server-sdk)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/js-sdks.svg?style=social&label=Star&maxAge=2592000)](https://github.com/devcyclehq/js-sdks)
 
-[//]: # (wizard-evaluate-start)
+[//]: # 'wizard-evaluate-start'
 
 ## User Object
 
@@ -44,7 +44,8 @@ if (value) {
   // Feature Flag on
 }
 ```
-[//]: # (wizard-evaluate-end)
+
+[//]: # 'wizard-evaluate-end'
 
 The default value can be of type string, boolean, number, or object.
 
@@ -64,7 +65,7 @@ See [getVariables](/bucketing-api/#tag/Bucketing-API/operation/getVariables) on 
 
 :::caution
 
-This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+This method is intended to be used for debugging and analytics purposes, _not_ as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
 Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
 of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
@@ -111,7 +112,7 @@ To assist with segmentation and bucketing you can set a custom data map that wil
 import { DVCCustomDataJSON } from '@devcycle/nodejs-server-sdk'
 
 const customData: DVCCustomDataJSON = {
-  'some-key': 'some-value'
+  'some-key': 'some-value',
 }
 
 devcycleClient.setClientCustomData(customData)
@@ -139,13 +140,10 @@ Once you have EdgeDB enabled in your project, pass in the enableEdgeDB option to
 ```typescript
 import { initializeDevCycle, DevCycleUser } from '@devcycle/nodejs-server-sdk'
 
-const devcycleClient = initializeDevCycle(
-  '<DEVCYCLE_SERVER_SDK_KEY>',
-  {
-    enableCloudBucketing: true,
-    enableEdgeDB: true,
-  },
-)
+const devcycleClient = initializeDevCycle('<DEVCYCLE_SERVER_SDK_KEY>', {
+  enableCloudBucketing: true,
+  enableEdgeDB: true,
+})
 
 const user: DevCycleUser = {
   user_id: 'test_user',
@@ -171,12 +169,47 @@ To disable realtime updates, pass in the `disableRealtimeUpdates` option to the 
 ```typescript
 import { initializeDevCycle } from '@devcycle/nodejs-server-sdk'
 
-const devcycleClient = initializeDevCycle(
-  '<DEVCYCLE_SERVER_SDK_KEY>',
-  {
-    disableRealtimeUpdates: true,
-  },
+const devcycleClient = initializeDevCycle('<DEVCYCLE_SERVER_SDK_KEY>', {
+  disableRealtimeUpdates: true,
+})
+```
+
+## Evaluation Hooks
+
+Using evaluation hooks, you can hook into the lifecycle of a variable evaluation to execute code before and after execution of the evaluation.
+
+**Note**: Each evaluation will wait for all hooks before returning the variable evaluation, which depending on the complexity of the hooks will cause slower function call times. This also may lead to blocking variable evaluations in the future until all hooks return depending on the volume of calls to `.variable`.
+
+> [!WARNING]
+> Do not call any variable evaluation functions (.variable/variableValue) in any of the hooks, as it may cause infinite recursion.
+
+To add a hook:
+
+```typescript
+const client = new DevCycleClient('token')
+client.addHook(
+  new EvalHook(
+    (context) => {
+      // before hook
+    },
+    (context, variableDetails) => {
+      // after hook
+    },
+    (context, variableDetails) => {
+      // onFinally hook
+    },
+    (context, variableDetails) => {
+      // error hook
+    },
+  ),
 )
+```
+
+You can also clear the hooks:
+
+```typescript
+const client = new DevCycleClient('token')
+client.clearHooks()
 ```
 
 ## Close Client

--- a/docs/sdk/server-side-sdks/php/php-usage.md
+++ b/docs/sdk/server-side-sdks/php/php-usage.md
@@ -9,7 +9,7 @@ sidebar_custom_props: { icon: material-symbols:toggle-on }
 [![Packagist](https://badgen.net/packagist/v/devcycle/php-server-sdk/latest)](https://packagist.org/packages/devcycle/php-server-sdk)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/php-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/php-server-sdk)
 
-[//]: # (wizard-evaluate-start)
+[//]: # 'wizard-evaluate-start'
 
 ## User Object
 
@@ -39,7 +39,8 @@ try {
     echo 'Exception when calling DevCycleClient->variableValue: ', $e->getMessage(), PHP_EOL;
 }
 ```
-[//]: # (wizard-evaluate-end)
+
+[//]: # 'wizard-evaluate-end'
 
 The default value can be of type string, boolean, number, or object.
 
@@ -61,7 +62,7 @@ See [getVariables](/bucketing-api/#tag/Bucketing-API/operation/getVariables) on 
 
 :::caution
 
-This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+This method is intended to be used for debugging and analytics purposes, _not_ as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
 Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
 of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
@@ -125,6 +126,41 @@ $result = $devcycleClient->allVariables($user_data);
 $devcycleClient->allVariablesAsync($user_data)->then(function($result) {
   print_r($result);
 });
+```
+
+## Evaluation Hooks
+
+Using evaluation hooks, you can hook into the lifecycle of a variable evaluation to execute code before and after execution of the evaluation.
+
+**Note**: Each evaluation will wait for all hooks before returning the variable evaluation, which depending on the complexity of the hooks will cause slower function call times. This also may lead to blocking variable evaluations in the future until all hooks return depending on the volume of calls to `.variable`.
+
+> [!WARNING]
+> Do not call any variable evaluation functions (.variable/variableValue) in any of the hooks, as it may cause infinite recursion.
+
+To add a hook:
+
+```php
+$hook = new EvalHook(
+    before: function (HookContext $context) use (&$beforeCalled) {
+        // before hook
+    },
+    after: function (HookContext $context) use (&$afterCalled) {
+        // after hook
+    },
+    onFinally: function (HookContext $context) use (&$onFinallyCalled) {
+        // onFinally hook
+    },
+    error: function (HookContext $context, \Exception $error) use (&$errorCalled) {
+        // error hook
+    }
+);
+$this->client->addHook($hook);
+```
+
+You can also clear the hooks:
+
+```php
+$this->client->clearHooks();
 ```
 
 ## Models

--- a/docs/sdk/server-side-sdks/python/python-usage.md
+++ b/docs/sdk/server-side-sdks/python/python-usage.md
@@ -9,7 +9,7 @@ sidebar_custom_props: { icon: material-symbols:toggle-on }
 [![PyPI](https://badgen.net/pypi/v/devcycle-python-server-sdk)](https://pypi.org/project/devcycle-python-server-sdk/)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/python-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/python-server-sdk)
 
-[//]: # (wizard-evaluate-start)
+[//]: # 'wizard-evaluate-start'
 
 ## DevCycleUser Object
 
@@ -44,7 +44,8 @@ try:
 except Exception as e:
      print(f"Exception when calling DevCycleLocalClient->variable_value: {e}")
 ```
-[//]: # (wizard-evaluate-end)
+
+[//]: # 'wizard-evaluate-end'
 
 The default value can be of type string, boolean, number, or dictionary.
 
@@ -68,7 +69,7 @@ See [getVariables](https://docs.devcycle.com/bucketing-api/#tag/Bucketing-API/op
 
 :::caution
 
-This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+This method is intended to be used for debugging and analytics purposes, _not_ as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
 Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
 of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
@@ -184,4 +185,43 @@ To disable realtime updates, pass in the `disable_realtime_updates` option to th
 options = DevCycleLocalOptions(disable_realtime_updates=True)
 
 devcycle_client = DevCycleLocalClient(os.environ["DEVCYCLE_SERVER_SDK_KEY"], options)
+```
+
+## Evaluation Hooks
+
+Using evaluation hooks, you can hook into the lifecycle of a variable evaluation to execute code before and after execution of the evaluation.
+
+**Note**: Each evaluation will wait for all hooks before returning the variable evaluation, which depending on the complexity of the hooks will cause slower function call times. This also may lead to blocking variable evaluations in the future until all hooks return depending on the volume of calls to `.variable`.
+
+> [!WARNING]
+> Do not call any variable evaluation functions (.variable/variableValue) in any of the hooks, as it may cause infinite recursion.
+
+To add a hook:
+
+```python
+def before_hook(context):
+    # before hook
+    return context
+
+def after_hook(context, variable):
+    # after hook
+    return context, variable
+
+def finally_hook(context, variable):
+    # finally hook
+    return context, variable
+
+def error_hook(context, error):
+    # error hook
+    return context, error
+
+self.client.add_hook(
+    EvalHook(before_hook, after_hook, finally_hook, error_hook)
+)
+```
+
+You can also clear the hooks:
+
+```python
+self.client.clear_hooks()
 ```

--- a/docs/sdk/server-side-sdks/ruby/ruby-usage.md
+++ b/docs/sdk/server-side-sdks/ruby/ruby-usage.md
@@ -9,7 +9,7 @@ sidebar_custom_props: { icon: simple-icons:ruby }
 [![RubyGems](https://badgen.net/rubygems/v/devcycle-ruby-server-sdk/latest)](https://rubygems.org/gems/devcycle-ruby-server-sdk)
 [![GitHub](https://img.shields.io/github/stars/devcyclehq/ruby-server-sdk.svg?style=social&label=Star&maxAge=2592000)](https://github.com/DevCycleHQ/ruby-server-sdk)
 
-[//]: # (wizard-evaluate-start)
+[//]: # 'wizard-evaluate-start'
 
 ## User Object
 
@@ -39,7 +39,8 @@ rescue
   puts "Exception when calling DevCycle::Client->variable_value"
 end
 ```
-[//]: # (wizard-evaluate-end)
+
+[//]: # 'wizard-evaluate-end'
 
 The default value can be of type string, boolean, number, or object.
 
@@ -76,7 +77,7 @@ end
 
 :::caution
 
-This method is intended to be used for debugging and analytics purposes, *not* as a method for retrieving the value of Variables to change code behaviour.
+This method is intended to be used for debugging and analytics purposes, _not_ as a method for retrieving the value of Variables to change code behaviour.
 For that purpose, we strongly recommend using the individual variable access method described in [Get and use Variable by key](#get-and-use-variable-by-key)
 Using this method instead will result in no evaluation events being tracked for individual variables, and will not allow the use
 of other DevCycle features such as [Code Usage detection](/integrations/github/feature-usage-action)
@@ -183,4 +184,39 @@ user = DevCycle::User.new({
    email: 'example@example.ca',
    country: 'CA'
  })
+```
+
+## Evaluation Hooks
+
+Using evaluation hooks, you can hook into the lifecycle of a variable evaluation to execute code before and after execution of the evaluation.
+
+**Note**: Each evaluation will wait for all hooks before returning the variable evaluation, which depending on the complexity of the hooks will cause slower function call times. This also may lead to blocking variable evaluations in the future until all hooks return depending on the volume of calls to `.variable`.
+
+> [!WARNING]
+> Do not call any variable evaluation functions (.variable/variableValue) in any of the hooks, as it may cause infinite recursion.
+
+To add a hook:
+
+```ruby
+hook = DevCycle::EvalHook.new(
+  before: ->(context) {
+    # before hook
+  }
+  after: ->(context) {
+    # after hook
+  },
+  error: ->(context, error) {
+    # error hook
+  },
+  on_finally: ->(context) {
+    # finally hook
+  }
+)
+client.add_eval_hook(hook)
+```
+
+You can also clear the hooks:
+
+```ruby
+client.clear_eval_hooks
 ```


### PR DESCRIPTION
# Changes

- added docs for evaluation hooks

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
