### PR TITLE
Update SDK documentation to include 'eval' field in Variable object

### DIFF
--- a/docs/sdk/server-side-sdks/dotnet/dotnet-usage.md
+++ b/docs/sdk/server-side-sdks/dotnet/dotnet-usage.md
@@ -37,7 +37,7 @@ bool result = await client.VariableValue(user, "your-variable-key", true);
 The default value can be of type `String`, `Boolean`, `Number`, or `Object`.
 
 If you would like to get the full Variable object you can use `Variable()` instead. This contains properties such as:
-`Key`, `Value`, `Type`, `DefaultValue`, `IsDefaulted`.
+`Key`, `Value`, `Type`, `DefaultValue`, `IsDefaulted`, `Eval`: evaluation object containing reason, details, and targetId for why the Variable was bucketed into its value (see [Evaluation Reasons](/sdk/features#evaluation-reasons)).
 
 ## Getting All Variables
 

--- a/docs/sdk/server-side-sdks/go/go-usage.md
+++ b/docs/sdk/server-side-sdks/go/go-usage.md
@@ -51,7 +51,7 @@ This helps to protect your code against unexpected types being returned from the
 To avoid confusion when testing new variables, make sure you're using the correct type for the defaultValue parameter.
 
 To access the full Variable Object use `devcycleClient.Variable(user, "my-variable-key", "test")` instead.
-This will return a `Variable` object containing the `key`, `value`, `type`, `defaultValue`, `isDefaulted` fields.
+This will return a `Variable` object containing the `key`, `value`, `type`, `defaultValue`, `isDefaulted`, `eval`: evaluation object containing reason, details, and targetId for why the Variable was bucketed into its value (see [Evaluation Reasons](/sdk/features#evaluation-reasons)) fields.
 The same rules apply for the `value` field as above for `VariableValue`.
 
 ## Track Event

--- a/docs/sdk/server-side-sdks/java/java-usage.md
+++ b/docs/sdk/server-side-sdks/java/java-usage.md
@@ -46,7 +46,7 @@ if (variableValue.booleanValue()) {
 The default value can be of type `String`, `Boolean`, `Number`, or `Object`.
 
 If you would like to get the full Variable Object you can use `variable()` instead. This contains fields such as:
-`key`, `value`, `type`, `defaultValue`, `isDefaulted`.
+`key`, `value`, `type`, `defaultValue`, `isDefaulted`, `eval`: evaluation object containing reason, details, and targetId for why the Variable was bucketed into its value (see [Evaluation Reasons](/sdk/features#evaluation-reasons)).
 
 ## Getting All Variables
 

--- a/docs/sdk/server-side-sdks/node/node-usage.md
+++ b/docs/sdk/server-side-sdks/node/node-usage.md
@@ -51,7 +51,7 @@ The default value can be of type string, boolean, number, or object.
 
 If you would like to get the full Variable object defined by [DVCVariable Typescript Schema](https://github.com/search?q=repo%3ADevCycleHQ%2Fjs-sdks+export+interface+DVCVariable%3C+language%3ATypeScript+path%3A*types.ts&type=code)
 you can use `devcycleClient.variable()` instead. This contains fields such as:
-`key`, `value`, `type`, `defaultValue`, `isDefaulted`.
+`key`, `value`, `type`, `defaultValue`, `isDefaulted`, `eval`: evaluation object containing reason, details, and targetId for why the Variable was bucketed into its value (see [Evaluation Reasons](/sdk/features#evaluation-reasons)).
 
 ## Getting All Variables
 
@@ -172,7 +172,6 @@ import { initializeDevCycle } from '@devcycle/nodejs-server-sdk'
 const devcycleClient = initializeDevCycle('<DEVCYCLE_SERVER_SDK_KEY>', {
   disableRealtimeUpdates: true,
 })
-
 ```
 
 ## Evaluation Hooks

--- a/docs/sdk/server-side-sdks/php/php-usage.md
+++ b/docs/sdk/server-side-sdks/php/php-usage.md
@@ -45,7 +45,8 @@ try {
 The default value can be of type string, boolean, number, or object.
 
 If you would like to get the full Variable object defined by [getVariableByKey](/bucketing-api/#tag/Bucketing-API/operation/getVariableByKey)
-you can use `variable()` instead of `variableValue()`.
+you can use `variable()` instead of `variableValue()`. This contains fields such as:
+`key`, `value`, `type`, `defaultValue`, `isDefaulted`, `eval`: evaluation object containing reason, details, and targetId for why the Variable was bucketed into its value (see [Evaluation Reasons](/sdk/features#evaluation-reasons)).
 
 ## Get all Variables
 

--- a/docs/sdk/server-side-sdks/python/python-usage.md
+++ b/docs/sdk/server-side-sdks/python/python-usage.md
@@ -50,7 +50,7 @@ except Exception as e:
 The default value can be of type string, boolean, number, or dictionary.
 
 If you would like to get the full Variable you can use `variable()` instead. This contains fields such as:
-`key`, `value`, `type`, `defaultValue`, `isDefaulted`.
+`key`, `value`, `type`, `defaultValue`, `isDefaulted`, `eval`: evaluation object containing reason, details, and targetId for why the Variable was bucketed into its value (see [Evaluation Reasons](/sdk/features#evaluation-reasons)).
 
 ## Getting All Variables
 

--- a/docs/sdk/server-side-sdks/ruby/ruby-usage.md
+++ b/docs/sdk/server-side-sdks/ruby/ruby-usage.md
@@ -45,7 +45,7 @@ end
 The default value can be of type string, boolean, number, or object.
 
 If you would like to get the full Variable you can use `devcycle_client.variable()` instead. This contains fields such as:
-`key`, `value`, `type`, `defaultValue`, `isDefaulted`.
+`key`, `value`, `type`, `defaultValue`, `isDefaulted`, `eval`: evaluation object containing reason, details, and targetId for why the Variable was bucketed into its value (see [Evaluation Reasons](/sdk/features#evaluation-reasons)).
 
 ## Getting all Features
 


### PR DESCRIPTION
 This field provides evaluation details such as reason, details, and targetId for variable bucketing (see [Evaluation Reasons](/sdk/features#evaluation-reasons)).