### PR TITLE
docs: reorder MCP client tabs and rename CLI docs to cli-reference

### DIFF
--- a/docs/cli-mcp/mcp-getting-started.md
+++ b/docs/cli-mcp/mcp-getting-started.md
@@ -93,6 +93,37 @@ To open VS Code and automatically add the DevCycle MCP, click the install button
 8. You'll be redirected back to VS Code with the server now active
 
 </TabItem>
+<TabItem value="claude-code" label="Claude Code">
+
+**Step 1: Open Terminal**
+Open your terminal to access the Claude CLI.
+
+**Step 2: Add DevCycle MCP Server**
+
+```bash
+claude mcp add --transport http devcycle https://mcp.devcycle.com/mcp
+```
+
+**Step 3: Manage MCP Connection**
+In the Claude CLI, enter the MCP management interface:
+
+```bash
+/mcp
+```
+
+**Step 4: Authentication**
+You'll see the DevCycle server listed as "disconnected • Enter to login":
+
+1. Select the DevCycle server and press Enter to login
+2. Follow the CLI prompts to initiate the Authentication process
+3. This will open a browser page at `mcp.devcycle.com` for authorization
+4. Review and click **"Allow Access"** to grant permissions
+5. If you have multiple organizations, select your desired organization at `auth.devcycle.com`
+6. Return to Claude Code where the server will show as connected
+
+For more details, see the [Claude Code MCP documentation](https://docs.anthropic.com/claude/docs/mcp).
+
+</TabItem>
 <TabItem value="claude" label="Claude Desktop">
 
 **Step 1: Access MCP Configuration**
@@ -133,37 +164,6 @@ Close and reopen Claude Desktop for the changes to take effect.
 3. Review and click **"Allow Access"** to grant permissions
 4. If you have multiple organizations, select your desired organization at `auth.devcycle.com`
 5. Return to Claude Desktop where the MCP tools will be active
-
-</TabItem>
-<TabItem value="claude-code" label="Claude Code">
-
-**Step 1: Open Terminal**
-Open your terminal to access the Claude CLI.
-
-**Step 2: Add DevCycle MCP Server**
-
-```bash
-claude mcp add --transport http devcycle https://mcp.devcycle.com/mcp
-```
-
-**Step 3: Manage MCP Connection**
-In the Claude CLI, enter the MCP management interface:
-
-```bash
-/mcp
-```
-
-**Step 4: Authentication**
-You'll see the DevCycle server listed as "disconnected • Enter to login":
-
-1. Select the DevCycle server and press Enter to login
-2. Follow the CLI prompts to initiate the Authentication process
-3. This will open a browser page at `mcp.devcycle.com` for authorization
-4. Review and click **"Allow Access"** to grant permissions
-5. If you have multiple organizations, select your desired organization at `auth.devcycle.com`
-6. Return to Claude Code where the server will show as connected
-
-For more details, see the [Claude Code MCP documentation](https://docs.anthropic.com/claude/docs/mcp).
 
 </TabItem>
 <TabItem value="windsurf" label="Windsurf">

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -132,6 +132,7 @@ const config = {
         modifyContent: (filename, content) => {
           if (filename.includes('README')) {
             return {
+              filename: 'cli-reference.md',
               // reduce headers to use with table of contents
               content: content.replace(/#\s/g, '## '),
             }

--- a/sidebars.js
+++ b/sidebars.js
@@ -108,13 +108,14 @@ module.exports = {
       type: 'category',
       label: 'CLI',
       className: 'section-title cli',
+      link: { type: 'doc', id: 'cli/cli-reference' },
       collapsible: true,
       collapsed: true,
       items: [
         {
           type: 'doc',
           label: 'CLI Reference',
-          id: 'cli/README',
+          id: 'cli/cli-reference',
         },
         {
           type: 'category',
@@ -129,6 +130,7 @@ module.exports = {
       type: 'category',
       label: 'MCP',
       className: 'section-title mcp',
+      link: { type: 'doc', id: 'cli-mcp/mcp-getting-started' },
       collapsible: true,
       collapsed: true,
       items: [


### PR DESCRIPTION
## Documentation Improvements

### Changes Made

- **Reorder MCP client tabs**: Swapped Claude Desktop and Claude Code order in MCP Getting Started guide
- **Add sidebar links**: Made CLI and MCP sidebar sections clickable
  - CLI section now links to CLI Reference page
  - MCP section now links to MCP Getting Started page
- **Rename CLI docs**: Changed CLI README.md to cli-reference.md for better naming consistency

### Impact

- Improved navigation: Users can now click sidebar sections to go directly to main pages
- Better UX: More intuitive client ordering in MCP setup instructions
- Cleaner file naming: CLI documentation now uses descriptive filename


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
