### PR TITLE
fix: Architecture Diagrams Readability in Dark Mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -385,3 +385,12 @@ html[data-theme='dark'] .DocSearch {
   background-color: #334155;
   color: #3b82f6 !important;
 }
+
+/* Architecture diagram dark mode fixes */
+[data-theme='dark'] img[src*="architecture-docs-diagrams"],
+[data-theme='dark'] img[src*="architexture-api-diagram"] {
+  background-color: white;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 16px;
+}


### PR DESCRIPTION
## Fix Architecture Diagrams Readability in Dark Mode

**Problem**: Architecture diagrams were unreadable in dark mode due to black strokes and dark text becoming invisible against dark backgrounds.

**Solution**: Added CSS targeting to apply white backgrounds with light borders and padding to architecture diagrams in dark mode only, preserving the original appearance in light mode.

**Changes**:
- Added dark mode CSS rules in `src/css/custom.css` for architecture diagram images
- Uses `[data-theme='dark']` selector to only apply styling in dark mode
- Targets diagrams by filename pattern (`architecture-docs-diagrams*` and `architexture-api-diagram*`)

**Result**: All architecture diagrams now have good contrast and readability in both light and dark themes.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
