### PR TITLE
fix: darkmode on more diagrams

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -388,7 +388,9 @@ html[data-theme='dark'] .DocSearch {
 
 /* Architecture diagram dark mode fixes */
 [data-theme='dark'] img[src*="architecture-docs-diagrams"],
-[data-theme='dark'] img[src*="architecture-api-diagram"] {
+[data-theme='dark'] img[src*="architecture-api-diagram"],
+[data-theme='dark'] img[src*="server-sdk-topology"],
+[data-theme='dark'] img[src*="sdk-proxy-topology"] {
   background-color: white;
   border: 1px solid #d1d5db;
   border-radius: 8px;


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
