### PR TITLE
fix debug tools and webdebugger redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -62,3 +62,5 @@
 /platform/custom-domains /platform/extras/custom-domains 301
 /platform/webhooks /platform/extras/webhooks 301
 /platform/advanced-targeting/feature-opt-in /platform/extras/feature-opt-in 301
+/platform/testing-and-qa/debug-tools /platform/testing-and-qa/debug-tools/evaluation-lookup 301
+/platform/testing-and-qa/web-debugger /platform/testing-and-qa/debug-tools/web-debugger 301


### PR DESCRIPTION
- fix the redirects from indexed pages


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
