### PR TITLE
chore: add registry.modelcontextprotocol.io refrence

### DIFF
--- a/docs/cli-mcp/mcp-getting-started.md
+++ b/docs/cli-mcp/mcp-getting-started.md
@@ -25,6 +25,8 @@ https://mcp.devcycle.com/mcp
 https://mcp.devcycle.com/sse
 ```
 
+**MCP Registry**: If you're using [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io), the DevCycle MCP is listed as: `com.devcycle/mcp`
+
 :::info
 
 These instructions use the remote DevCycle MCP server. For installation of the local MCP server, see the [reference docs](/cli-mcp/mcp-reference#local-mcp-server-installation).


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
