### PR TITLE
docs: update CLI version to v6.3.0

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -49,7 +49,7 @@ const YouTubeTransformer = {
  * Pinned version of the CLI to use for docs
  * When bumping the version, add any new commands to the documents array
  */
-const DVC_CLI_VERSION = 'v6.2.1' // auto updated by dvc cli release workflow
+const DVC_CLI_VERSION = 'v6.3.0' // auto updated by dvc cli release workflow
 
 const VSCODE_EXTENSION_VERSION = 'v1.4.10' // auto updated by extension release workflow
 


### PR DESCRIPTION
Updates the pinned `@devcycle/cli` version in `docusaurus.config.js` from `v6.2.1` to `v6.3.0`.