### PR TITLE
docs: align Java SDK documentation

### DIFF
--- a/docs/sdk/server-side-sdks/java/java-install.md
+++ b/docs/sdk/server-side-sdks/java/java-install.md
@@ -63,14 +63,14 @@ You can use the SDK in your Maven project by adding the following to your _pom.x
 <dependency>
     <groupId>com.devcycle</groupId>
     <artifactId>java-server-sdk</artifactId>
-    <version>LATEST</version>
+    <version>2.9.3</version>
     <scope>compile</scope>
 </dependency>
 ```
 
 :::info
 
-Refer to the latest version of the SDK on [maven central](https://maven.org/artifact/com.devcycle/java-server-sdk) if you would not prefer Maven or Gradle to pull the latest version automatically by using `+`
+Refer to [Maven Central](https://maven.org/artifact/com.devcycle/java-server-sdk) for the latest release. Pin the version in your build so upgrades are deliberate.
 
 :::
 
@@ -79,7 +79,7 @@ Refer to the latest version of the SDK on [maven central](https://maven.org/arti
 Alternatively you can use the SDK in your Gradle project by adding the following to _build.gradle_:
 
 ```yaml
-implementation("com.devcycle:java-server-sdk:+")
+implementation("com.devcycle:java-server-sdk:2.9.3")
 ```
 [//]: # 'wizard-install-end'
 

--- a/docs/sdk/server-side-sdks/java/java-install.md
+++ b/docs/sdk/server-side-sdks/java/java-install.md
@@ -63,14 +63,14 @@ You can use the SDK in your Maven project by adding the following to your _pom.x
 <dependency>
     <groupId>com.devcycle</groupId>
     <artifactId>java-server-sdk</artifactId>
-    <version>2.9.3</version>
+    <version>[2.9.3,3.0.0)</version>
     <scope>compile</scope>
 </dependency>
 ```
 
 :::info
 
-Refer to [Maven Central](https://maven.org/artifact/com.devcycle/java-server-sdk) for the latest release. Pin the version in your build so upgrades are deliberate.
+This range accepts compatible releases from `2.9.3` up to, but not including, `3.0.0`. Refer to [Maven Central](https://maven.org/artifact/com.devcycle/java-server-sdk) for the latest available release.
 
 :::
 
@@ -79,7 +79,7 @@ Refer to [Maven Central](https://maven.org/artifact/com.devcycle/java-server-sdk
 Alternatively you can use the SDK in your Gradle project by adding the following to _build.gradle_:
 
 ```yaml
-implementation("com.devcycle:java-server-sdk:2.9.3")
+implementation("com.devcycle:java-server-sdk:[2.9.3,3.0.0)")
 ```
 [//]: # 'wizard-install-end'
 

--- a/docs/sdk/server-side-sdks/java/java-openfeature.md
+++ b/docs/sdk/server-side-sdks/java/java-openfeature.md
@@ -38,7 +38,7 @@ You can use the Java SDK in your Maven project by adding the following to your _
 <dependency>
     <groupId>com.devcycle</groupId>
     <artifactId>java-server-sdk</artifactId>
-    <version>LATEST</version>
+    <version>2.9.3</version>
     <scope>compile</scope>
 </dependency>
 ```
@@ -54,7 +54,7 @@ Refer to the latest version of the SDK on [maven central](https://maven.org/arti
 Alternatively you can use the SDK in your Gradle project by adding the following to _build.gradle_:
 
 ```yaml
-implementation("com.devcycle:java-server-sdk:+")
+implementation("com.devcycle:java-server-sdk:2.9.3")
 ```
 [//]: # 'wizard-install-end'
 

--- a/docs/sdk/server-side-sdks/java/java-openfeature.md
+++ b/docs/sdk/server-side-sdks/java/java-openfeature.md
@@ -38,14 +38,14 @@ You can use the Java SDK in your Maven project by adding the following to your _
 <dependency>
     <groupId>com.devcycle</groupId>
     <artifactId>java-server-sdk</artifactId>
-    <version>2.9.3</version>
+    <version>[2.9.3,3.0.0)</version>
     <scope>compile</scope>
 </dependency>
 ```
 
 :::info
 
-Refer to the latest version of the SDK on [maven central](https://maven.org/artifact/com.devcycle/java-server-sdk) if you would not prefer Maven or Gradle to pull the latest version automatically by using `+`
+This range accepts compatible releases from `2.9.3` up to, but not including, `3.0.0`. Refer to [Maven Central](https://maven.org/artifact/com.devcycle/java-server-sdk) for the latest available release.
 
 :::
 
@@ -54,7 +54,7 @@ Refer to the latest version of the SDK on [maven central](https://maven.org/arti
 Alternatively you can use the SDK in your Gradle project by adding the following to _build.gradle_:
 
 ```yaml
-implementation("com.devcycle:java-server-sdk:2.9.3")
+implementation("com.devcycle:java-server-sdk:[2.9.3,3.0.0)")
 ```
 [//]: # 'wizard-install-end'
 

--- a/docs/sdk/server-side-sdks/java/java-usage.md
+++ b/docs/sdk/server-side-sdks/java/java-usage.md
@@ -114,6 +114,12 @@ customData.put("some-key", "some-value");
 client.setClientCustomData(customData);
 ```
 
+Close the client during application shutdown to stop background polling, realtime connections, and event queue workers:
+
+```java
+client.close();
+```
+
 ## Override Logging
 
 The SDK logs to stdout by default and does not require any specific logging package. To integrate with your own logging system, such as Java Logging or SLF4J, you can create a wrapper that implements the IDevCycleLogger interface. Then you can set the logger into the Java Server SDK setting the Custom Logger property in the options object used to initialize the client.

--- a/docs/sdk/server-side-sdks/java/java-usage.md
+++ b/docs/sdk/server-side-sdks/java/java-usage.md
@@ -114,6 +114,8 @@ customData.put("some-key", "some-value");
 client.setClientCustomData(customData);
 ```
 
+## Shutdown
+
 Close the client during application shutdown to stop background polling, realtime connections, and event queue workers:
 
 ```java


### PR DESCRIPTION
## Summary

- Replace exact Java SDK versions with the compatible Maven-style range `[2.9.3,3.0.0)`.
- Apply the range consistently to Maven, Gradle, and OpenFeature installation examples.
- Document that the range includes `2.9.3` and excludes `3.0.0`.
- Document client shutdown for background workers and connections.

## Validation

- `git diff --check` passed.