### PR TITLE
docs: document Java OpenFeature long values

### DIFF
--- a/docs/sdk/server-side-sdks/java/java-openfeature.md
+++ b/docs/sdk/server-side-sdks/java/java-openfeature.md
@@ -131,7 +131,8 @@ if (boolValue) {
 
 DevCycle numeric values are represented as doubles by the Java OpenFeature provider. When using
 `getLongValue()`, the value must be an integral number within the double safe-integer range:
-`-(2^53 - 1)` through `2^53 - 1` (`-9_007_199_254_740_991` through `9_007_199_254_740_991`).
+`-9_007_199_254_740_991` through `9_007_199_254_740_991`, the inclusive range of integers
+exactly representable by an IEEE-754 double.
 
 Fractional values and values outside this range return the supplied default value with a
 `TYPE_MISMATCH` error. Use `getDoubleValue()` when fractional values are required.

--- a/docs/sdk/server-side-sdks/java/java-openfeature.md
+++ b/docs/sdk/server-side-sdks/java/java-openfeature.md
@@ -103,6 +103,9 @@ String stringValue = openFeatureClient.getStringValue("string-flag", "default", 
 // Retrieve an integer flag value
 Integer intValue = openFeatureClient.getIntegerValue("integer-flag", 0, context);
 
+// Retrieve a long flag value
+Long longValue = openFeatureClient.getLongValue("long-flag", 0L, context);
+
 // Retrieve a double flag value
 Double doubleValue = openFeatureClient.getDoubleValue("double-flag", 0.0, context);
 
@@ -123,6 +126,15 @@ if (boolValue) {
 [//]: # 'wizard-evaluate-end'
 
 **NOTE: use `DevCycleCloudClient` \ `DevCycleCloudOptions` for Cloud Bucketing mode.**
+
+### Long Values
+
+DevCycle numeric values are represented as doubles by the Java OpenFeature provider. When using
+`getLongValue()`, the value must be an integral number within the double safe-integer range:
+`-(2^53 - 1)` through `2^53 - 1` (`-9_007_199_254_740_991` through `9_007_199_254_740_991`).
+
+Fractional values and values outside this range return the supplied default value with a
+`TYPE_MISMATCH` error. Use `getDoubleValue()` when fractional values are required.
 
 ### Required Targeting Key
 

--- a/docs/sdk/server-side-sdks/java/java-openfeature.md
+++ b/docs/sdk/server-side-sdks/java/java-openfeature.md
@@ -131,8 +131,7 @@ if (boolValue) {
 
 DevCycle numeric values are represented as doubles by the Java OpenFeature provider. When using
 `getLongValue()`, the value must be an integral number within the double safe-integer range:
-`-9_007_199_254_740_991` through `9_007_199_254_740_991`, the inclusive range of integers
-exactly representable by an IEEE-754 double.
+`-(2^53 - 1)` through `2^53 - 1` (`-9_007_199_254_740_991` through `9_007_199_254_740_991`).
 
 Fractional values and values outside this range return the supplied default value with a
 `TYPE_MISMATCH` error. Use `getDoubleValue()` when fractional values are required.


### PR DESCRIPTION
## Summary

- Document `getLongValue()` usage in the Java OpenFeature provider.
- Explain the `2^53 - 1` safe-integer limitation.
- Document `TYPE_MISMATCH` behavior for fractional and out-of-range values.

## Context

This documents the behavior introduced in [java-server-sdk PR #196](https://github.com/DevCycleHQ/java-server-sdk/pull/196), following the review question about whether the `2^53` limitation was documented.

See the [original review comment](https://github.com/DevCycleHQ/java-server-sdk/pull/196#pullrequestreview-4821459497).