### PR TITLE
docs: document async .NET OpenFeature initialization

### DIFF
--- a/docs/sdk/server-side-sdks/dotnet/dotnet-openfeature.md
+++ b/docs/sdk/server-side-sdks/dotnet/dotnet-openfeature.md
@@ -93,7 +93,7 @@ EvaluationContext ctx = EvaluationContext.Builder()
 ```
 [//]: # 'wizard-initialize-end'
 
-`SetProviderAsync` waits for the provider to finish initializing before it returns. This ensures that the Local Bucketing SDK has downloaded its initial configuration before you evaluate a flag.
+`SetProviderAsync` waits for the provider to finish initializing before it returns. For Local Bucketing, this includes waiting for the initial configuration to download before you evaluate a flag.
 
 Keep this initialization path asynchronous. Do not block on the returned task with `.Wait()`, `.Result`, or `.GetAwaiter().GetResult()`. Blocking can deadlock applications that use a UI or legacy ASP.NET synchronization context.
 

--- a/docs/sdk/server-side-sdks/dotnet/dotnet-openfeature.md
+++ b/docs/sdk/server-side-sdks/dotnet/dotnet-openfeature.md
@@ -67,7 +67,7 @@ Initialize the DevCycle SDK and set the DevCycleProvider as the provider for Ope
 ```csharp
 // Both Cloud, and Local are supported by the OpenFeature Provider. This example uses the Cloud Provider for sake of brevity in the configuration.
 var devCycleClient = new DevCycleCloudClientBuilder().SetEnvironmentKey(SDK_ENV_VAR).SetLogger(new NullLoggerFactory()).Build();
-OpenFeature.Api.Instance.SetProvider(devCycleClient.GetOpenFeatureProvider());
+await OpenFeature.Api.Instance.SetProviderAsync(devCycleClient.GetOpenFeatureProvider());
 
 FeatureClient oFeatureClient = OpenFeature.Api.Instance.GetClient();
 // The evaluation context is an example of a fully populated DevCycleUser. The only required value is a bucketing key of `user_id` or `targetingKey`
@@ -92,6 +92,10 @@ EvaluationContext ctx = EvaluationContext.Builder()
     .Build();
 ```
 [//]: # 'wizard-initialize-end'
+
+`SetProviderAsync` waits for the provider to finish initializing before it returns. This ensures that the Local Bucketing SDK has downloaded its initial configuration before you evaluate a flag.
+
+Keep this initialization path asynchronous. Do not block on the returned task with `.Wait()`, `.Result`, or `.GetAwaiter().GetResult()`. Blocking can deadlock applications that use a UI or legacy ASP.NET synchronization context.
 
 ### Evaluate a Variable
 Use a Variable value by passing the Variable key, default value, and EvaluationContext to one of the OpenFeature flag evaluation methods


### PR DESCRIPTION
## Summary

- Use `SetProviderAsync` in the .NET OpenFeature setup example.
- Document that provider initialization must remain asynchronous.
- Explain that blocking can deadlock UI and legacy ASP.NET synchronization contexts.

## Motivation

The .NET provider waits for Local Bucketing to download its initial configuration. The docs should show the async path and discourage blocking on the returned task.

Validation: `yarn docusaurus build`