### PR TITLE
chore: update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -15,7 +15,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v7
     - uses: byrnereese/github-action-mkdocs-link-check@1.0
       with:
         verbose-mode: 'yes'

--- a/.github/workflows/diagrams.yml
+++ b/.github/workflows/diagrams.yml
@@ -12,7 +12,7 @@ jobs:
     name: Generate
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
       - name: Get changed UML files
@@ -26,6 +26,6 @@ jobs:
           args: -v -tsvg "diagrams/**.puml" -o "../static/diagrams"
 
       - name: Push Local Changes
-        uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "Generate SVG files for PlantUML diagrams"

--- a/.github/workflows/diagrams.yml
+++ b/.github/workflows/diagrams.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Get changed UML files
         id: getfile
         run: |
-          echo "::set-output name=files::$(git diff --name-only HEAD^ HEAD | grep .puml | xargs)"
+          echo "files=$(git diff --name-only HEAD^ HEAD | grep .puml | xargs)" >> "$GITHUB_OUTPUT"
 
       - name: Generate SVG Diagrams
         uses: holowinski/plantuml-github-action@2e381afb2bae7e169b76bfb068e8d8b2089106ee
@@ -26,6 +26,6 @@ jobs:
           args: -v -tsvg "diagrams/**.puml" -o "../static/diagrams"
 
       - name: Push Local Changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "Generate SVG files for PlantUML diagrams"

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -9,7 +9,7 @@ jobs:
     name: License Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: DevCycleHQ/license-action@main
         with:
           language: "javascript"


### PR DESCRIPTION
## Summary

- Update GitHub Actions and custom action dependencies to Node 24-compatible releases.
- Update nested dependencies in composite and custom actions.
- Retain actions without an available Node 24 release.